### PR TITLE
Fix getLocationForm, throw error Cannot use object of type

### DIFF
--- a/src/Repositories/LocationRepository.php
+++ b/src/Repositories/LocationRepository.php
@@ -39,14 +39,14 @@ class LocationRepository
     {
         $clickLocation = Location::get($ip);
 
-        if (! $clickLocation) {
+        if (!$clickLocation) {
             return LocationRepository::locationUnknown($ip);
         }
 
-        $clickLocation['longitude'] = (float) $clickLocation['longitude'];
-        $clickLocation['latitude'] = (float) $clickLocation['latitude'];
+        $clickLocation->longitude = (float) $clickLocation->longitude;
+        $clickLocation->latitude = (float) $clickLocation->latitude;
 
-        unset($clickLocation['driver']);
+        unset($clickLocation->driver);
 
         return $clickLocation->toArray();
     }


### PR DESCRIPTION
This method use Lcoation result, which is object not an Array and I got 
`Cannot use object of type Stevebauman\Location\Position as array`
So change it.
