### PR TITLE
feat: Laravel 13 support, custom-prefix routing, and redirect/security hardening

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+/.* export-ignore
+/.github export-ignore
+/content export-ignore
+/docs export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/CONTRIBUTING.md export-ignore
+/Dockerfile export-ignore
+/docker-compose.yml export-ignore
+/phpunit.xml export-ignore

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -10,26 +10,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4, 8.5]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.2, 8.3, 8.4, 8.5]
+        laravel: [12.*, 13.*]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-          - laravel: 11.*
-            testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
         exclude:
-          # Laravel 10 only supports PHP 8.1-8.3
-          - php: 8.4
-            laravel: 10.*
-          - php: 8.5
-            laravel: 10.*
-          # Laravel 11+ requires PHP 8.2+
-          - php: 8.1
-            laravel: 11.*
-          - php: 8.1
-            laravel: 12.*
+          # Laravel 13 requires PHP 8.3+
+          - php: 8.2
+            laravel: 13.*
 
     name: PHP${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## Unreleased
+
+- Add Laravel 13 compatibility and update CI coverage for Laravel 12/13 on PHP 8.2-8.5.
+- Add redirect-specific click tracking that avoids reloading the short URL during redirect handling.
+- Keep expired redirect events on a fully-loaded `ShortUrl` payload.
+- Add DNS-based private IP validation for shortened URLs and document its fail-open lookup behavior.
+- Treat `withOpenLimit(0)` as unlimited and reject negative open limits.
+- Allow filtering clicks by failure activation outcomes and validate status filters as arrays.
+- Treat non-expiring URLs as active and normalize expiring status timestamp comparisons.
+- Make registered `withPrefix()` overrides affect generated URLs and reject unregistered prefixes that package routes cannot resolve.
+- Add tagged publishing for config, views, and migrations.
+- Add Composer export cleanup via `.gitattributes`.
+- Remove `minimum-stability: dev` after validating Laravel 12/13 dependency resolution with stable packages.
+- Fix README click filter examples and update documented requirements for Laravel 13.
+- Convert PHPUnit doc-comment metadata to attributes to remove PHPUnit 11 deprecation notices.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ and soft delete/restore out of the box for your Laravel applications.
 
 ## Requirements
 
-- PHP 8.1+
-- Laravel 10.x, 11.x, or 12.x
+- PHP 8.1+ (PHP 8.3+ when using Laravel 13)
+- Laravel 10.x, 11.x, 12.x, or 13.x
 
 ## Installation
 
@@ -39,6 +39,13 @@ composer require yorcreative/laravel-urlshortener
 Publish the packages assets.
 ```bash
 php artisan vendor:publish --provider="YorCreative\UrlShortener\UrlShortenerServiceProvider"
+```
+
+You can also publish assets by tag.
+```bash
+php artisan vendor:publish --tag=urlshortener-config
+php artisan vendor:publish --tag=urlshortener-views
+php artisan vendor:publish --tag=urlshortener-migrations
 ```
 
 Run migrations.
@@ -249,8 +256,9 @@ $clicks = ClickService::get([
         1, // successful_routed
         2, // successful_protected
         3, // failure_password
-        4, // failure_expiration
-        5  // failure_limit
+        4, // failure_limit
+        5, // failure_expiration
+        6, // failure_activation
     ]
 ]);
 ```
@@ -270,7 +278,7 @@ Filtered on YorShortUrl Identifier(s)
 
 ```php
 $clicks = ClickService::get([
-    'identifier' => [
+    'identifiers' => [
          'xyz',
          'yxz'
     ]
@@ -310,8 +318,8 @@ Iterate Through Results With Batches
 
 ```php
 $clicks = ClickService::get([
-    'limit' => 500
-    'offset' => 1500
+    'limit' => 500,
+    'offset' => 1500,
 ]);
 
 $clicks->get('results');
@@ -328,19 +336,19 @@ Putting it all Together
 $clicks = ClickService::get([
     'ownership' => Model::whereIn('id', [1,2,3,4])->get()->toArray(),
     'outcome' => [
-        3 // successful_routed
+        1, // successful_routed
     ],
     'status' => [
-        'active'
+        'active',
     ],
     'utm_campaign' => [
-        'awareness'
+        'awareness',
     ],
     'utm_source' => [
-        'github'
+        'github',
     ],
-    'limit' => 500
-    'offset' => 1500
+    'limit' => 500,
+    'offset' => 1500,
 ]);
 ```
 
@@ -441,6 +449,12 @@ $url = UrlService::shorten('https://example.com/long-url')
     ->withPrefix('custom')
     ->build();
 
+// Custom prefixes must be registered so package routes can resolve them:
+// config/urlshortener.php
+'routing' => [
+    'additional_prefixes' => ['custom'],
+],
+
 // Custom identifier length
 $url = UrlService::shorten('https://example.com/long-url')
     ->forDomain('short.io')
@@ -491,6 +505,7 @@ URL_SHORTENER_VALIDATE_URLS=true
     'enabled' => env('URL_SHORTENER_VALIDATE_URLS', false),
     'allowed_schemes' => ['http', 'https'],
     'block_private_ips' => env('URL_SHORTENER_BLOCK_PRIVATE_IPS', true),
+    'resolve_dns_private_ips' => env('URL_SHORTENER_RESOLVE_DNS_PRIVATE_IPS', true),
     'blocked_hosts' => [
         // 'internal.company.com',
     ],
@@ -505,6 +520,8 @@ URL_SHORTENER_VALIDATE_URLS=true
 - Private IP ranges (SSRF)
 - Cloud metadata endpoints (SSRF)
 - Localhost redirects
+
+When DNS private IP checks are enabled, hostnames are resolved during URL creation and any private or reserved resolved IP is rejected. DNS lookup failures or hosts with no IP records are allowed, so add known internal hostnames to `blocked_hosts` when they should always be rejected.
 
 ### Rate Limiting for Password-Protected URLs
 
@@ -533,6 +550,7 @@ After exceeding the maximum attempts, users receive a `429 Too Many Requests` re
 | `URL_SHORTENER_DOMAINS_DATABASE` | `false` | Store domain config in database |
 | `URL_SHORTENER_VALIDATE_URLS` | `false` | Enable URL validation (recommended) |
 | `URL_SHORTENER_BLOCK_PRIVATE_IPS` | `true` | Block private/internal IPs |
+| `URL_SHORTENER_RESOLVE_DNS_PRIVATE_IPS` | `true` | Resolve hostnames and block private/reserved IP results |
 | `URL_SHORTENER_BLOCK_METADATA` | `true` | Block cloud metadata endpoints |
 | `URL_SHORTENER_PASSWORD_MAX_ATTEMPTS` | `5` | Max password attempts before rate limit |
 | `URL_SHORTENER_PASSWORD_DECAY_MINUTES` | `1` | Minutes until rate limit resets |
@@ -547,4 +565,3 @@ composer test
 
 - [Yorda](https://github.com/yordadev)
 - [All Contributors](../../contributors)
-

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
         "laravel url shortener",
         "laravel url"
     ],
-    "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
         "stevebauman/location": "^7.0"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
         "laravel/pint": "^1.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "phpunit/phpunit": "^10.0|^11.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "53ede9199dd21749ba2858ae92d0ec85",
+    "content-hash": "bfeb588ec13910da49b2834932b5e9e0",
     "packages": [
         {
             "name": "brick/math",
@@ -137,16 +137,16 @@
         },
         {
             "name": "composer/ca-bundle",
-            "version": "dev-main",
+            "version": "1.5.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "5035cb24d5c8884364a40a72205ed6f4a3db56b9"
+                "reference": "00a2f4201641d5c53f7fc0195e6c8d9fcc321a78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/5035cb24d5c8884364a40a72205ed6f4a3db56b9",
-                "reference": "5035cb24d5c8884364a40a72205ed6f4a3db56b9",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/00a2f4201641d5c53f7fc0195e6c8d9fcc321a78",
+                "reference": "00a2f4201641d5c53f7fc0195e6c8d9fcc321a78",
                 "shasum": ""
             },
             "require": {
@@ -160,7 +160,6 @@
                 "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "symfony/process": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -194,7 +193,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/main"
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.12"
             },
             "funding": [
                 {
@@ -206,11 +205,11 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-02T12:33:54+00:00"
+            "time": "2026-05-19T11:26:22+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
-            "version": "dev-main",
+            "version": "v3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
@@ -232,7 +231,6 @@
                 "squizlabs/php_codesniffer": "^3.5",
                 "vimeo/psalm": "^4.0.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -286,23 +284,23 @@
         },
         {
             "name": "doctrine/inflector",
-            "version": "2.2.x-dev",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "65c8fca3df76f968506fb30f83e8352223f829cd"
+                "reference": "6d6c96277ea252fc1304627204c3d5e6e15faa3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/65c8fca3df76f968506fb30f83e8352223f829cd",
-                "reference": "65c8fca3df76f968506fb30f83e8352223f829cd",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/6d6c96277ea252fc1304627204c3d5e6e15faa3b",
+                "reference": "6d6c96277ea252fc1304627204c3d5e6e15faa3b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^12.0 || ^14.0",
+                "doctrine/coding-standard": "^12.0 || ^13.0",
                 "phpstan/phpstan": "^1.12 || ^2.0",
                 "phpstan/phpstan-phpunit": "^1.4 || ^2.0",
                 "phpstan/phpstan-strict-rules": "^1.6 || ^2.0",
@@ -356,7 +354,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/inflector/issues",
-                "source": "https://github.com/doctrine/inflector/tree/2.2.x"
+                "source": "https://github.com/doctrine/inflector/tree/2.1.0"
             },
             "funding": [
                 {
@@ -372,29 +370,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-18T09:59:11+00:00"
+            "time": "2025-08-10T19:31:58+00:00"
         },
         {
             "name": "doctrine/lexer",
-            "version": "3.1.x-dev",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "200aa4fbd2df429ad49fcee637f05d44c32c2d17"
+                "reference": "31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/200aa4fbd2df429ad49fcee637f05d44c32c2d17",
-                "reference": "200aa4fbd2df429ad49fcee637f05d44c32c2d17",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd",
+                "reference": "31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^14",
+                "doctrine/coding-standard": "^12",
                 "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^10.5.58"
+                "phpunit/phpunit": "^10.5",
+                "psalm/plugin-phpunit": "^0.18.3",
+                "vimeo/psalm": "^5.21"
             },
             "type": "library",
             "autoload": {
@@ -431,7 +431,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/3.1.x"
+                "source": "https://github.com/doctrine/lexer/tree/3.0.1"
             },
             "funding": [
                 {
@@ -447,20 +447,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T20:53:36+00:00"
+            "time": "2024-02-05T11:56:58+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
-            "version": "dev-master",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dragonmantank/cron-expression.git",
-                "reference": "d425a2403c17d7cf911c55a7170f073979a9f382"
+                "reference": "d61a8a9604ec1f8c3d150d09db6ce98b32675013"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/d425a2403c17d7cf911c55a7170f073979a9f382",
-                "reference": "d425a2403c17d7cf911c55a7170f073979a9f382",
+                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/d61a8a9604ec1f8c3d150d09db6ce98b32675013",
+                "reference": "d61a8a9604ec1f8c3d150d09db6ce98b32675013",
                 "shasum": ""
             },
             "require": {
@@ -471,10 +471,9 @@
             },
             "require-dev": {
                 "phpstan/extension-installer": "^1.4.3",
-                "phpstan/phpstan": "^2.1.31",
-                "phpunit/phpunit": "^11.5.43 || ^12.4"
+                "phpstan/phpstan": "^1.12.32|^2.1.31",
+                "phpunit/phpunit": "^8.5.48|^9.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -504,7 +503,7 @@
             ],
             "support": {
                 "issues": "https://github.com/dragonmantank/cron-expression/issues",
-                "source": "https://github.com/dragonmantank/cron-expression/tree/master"
+                "source": "https://github.com/dragonmantank/cron-expression/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -512,11 +511,11 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-20T20:18:24+00:00"
+            "time": "2025-10-31T18:51:33+00:00"
         },
         {
             "name": "egulias/email-validator",
-            "version": "4.x-dev",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
@@ -540,7 +539,6 @@
             "suggest": {
                 "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -713,7 +711,7 @@
         },
         {
             "name": "graham-campbell/result-type",
-            "version": "1.1.x-dev",
+            "version": "v1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GrahamCampbell/Result-Type.git",
@@ -732,7 +730,6 @@
             "require-dev": {
                 "phpunit/phpunit": "^8.5.41 || ^9.6.22 || ^10.5.45 || ^11.5.7"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -760,7 +757,7 @@
             ],
             "support": {
                 "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
-                "source": "https://github.com/GrahamCampbell/Result-Type/tree/1.1"
+                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.4"
             },
             "funding": [
                 {
@@ -776,25 +773,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.x-dev",
+            "version": "7.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "eaa81598031cf57a9e36258c8546defffc994cba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/eaa81598031cf57a9e36258c8546defffc994cba",
+                "reference": "eaa81598031cf57a9e36258c8546defffc994cba",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.12",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -803,8 +801,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.5",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -812,7 +811,6 @@
                 "ext-intl": "Required for Internationalized Domain Name (IDN) support",
                 "psr/log": "Required for using the Log middleware"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "bamarni-bin": {
@@ -883,7 +881,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.12.0"
             },
             "funding": [
                 {
@@ -899,30 +897,30 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-06-16T22:11:48+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.x-dev",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "bamarni-bin": {
@@ -967,7 +965,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
             },
             "funding": [
                 {
@@ -983,27 +981,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-06-02T12:23:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.x-dev",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "9b38012e7b54f594707e6db52c684dc0a74b3a43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9b38012e7b54f594707e6db52c684dc0a74b3a43",
+                "reference": "9b38012e7b54f594707e6db52c684dc0a74b3a43",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -1011,13 +1011,13 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "http-interop/http-factory-tests": "1.1.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "bamarni-bin": {
@@ -1084,7 +1084,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.0"
             },
             "funding": [
                 {
@@ -1100,20 +1100,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-06-16T21:50:11+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "1.0.x-dev",
+            "version": "v1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1"
+                "reference": "7fe811c23a9e3cd712b4389eaeb50b5456d8c529"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/4f4bbd4e7172148801e76e3decc1e559bdee34e1",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/7fe811c23a9e3cd712b4389eaeb50b5456d8c529",
+                "reference": "7fe811c23a9e3cd712b4389eaeb50b5456d8c529",
                 "shasum": ""
             },
             "require": {
@@ -1122,10 +1122,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "uri-template/tests": "1.0.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "bamarni-bin": {
@@ -1171,7 +1170,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.5"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.7"
             },
             "funding": [
                 {
@@ -1187,28 +1186,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:27:06+00:00"
+            "time": "2026-06-12T21:33:43+00:00"
         },
         {
             "name": "laravel/framework",
-            "version": "12.x-dev",
+            "version": "v13.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "81518e8e1c28a6d7329f502bc62a1c4ea968b93e"
+                "reference": "6135650d69bd9442e470bb1b343422081b076f1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/81518e8e1c28a6d7329f502bc62a1c4ea968b93e",
-                "reference": "81518e8e1c28a6d7329f502bc62a1c4ea968b93e",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/6135650d69bd9442e470bb1b343422081b076f1e",
+                "reference": "6135650d69bd9442e470bb1b343422081b076f1e",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.11|^0.12|^0.13|^0.14",
+                "brick/math": "^0.14.2 || ^0.15 || ^0.16 || ^0.17",
                 "composer-runtime-api": "^2.2",
                 "doctrine/inflector": "^2.0.5",
                 "dragonmantank/cron-expression": "^3.4",
-                "egulias/email-validator": "^3.2.1|^4.0",
+                "egulias/email-validator": "^4.0",
                 "ext-ctype": "*",
                 "ext-filter": "*",
                 "ext-hash": "*",
@@ -1218,35 +1217,36 @@
                 "ext-tokenizer": "*",
                 "fruitcake/php-cors": "^1.3",
                 "guzzlehttp/guzzle": "^7.8.2",
+                "guzzlehttp/promises": "^2.0.3",
                 "guzzlehttp/uri-template": "^1.0",
                 "laravel/prompts": "^0.3.0",
-                "laravel/serializable-closure": "^1.3|^2.0",
-                "league/commonmark": "^2.7",
+                "laravel/serializable-closure": "^2.0.10",
+                "league/commonmark": "^2.8.1",
                 "league/flysystem": "^3.25.1",
                 "league/flysystem-local": "^3.25.1",
                 "league/uri": "^7.5.1",
                 "monolog/monolog": "^3.0",
                 "nesbot/carbon": "^3.8.4",
                 "nunomaduro/termwind": "^2.0",
-                "php": "^8.2",
-                "psr/container": "^1.1.1|^2.0.1",
-                "psr/log": "^1.0|^2.0|^3.0",
-                "psr/simple-cache": "^1.0|^2.0|^3.0",
+                "php": "^8.3",
+                "psr/container": "^1.1.1 || ^2.0.1",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
                 "ramsey/uuid": "^4.7",
-                "symfony/console": "^7.2.0",
-                "symfony/error-handler": "^7.2.0",
-                "symfony/finder": "^7.2.0",
-                "symfony/http-foundation": "^7.2.0",
-                "symfony/http-kernel": "^7.2.0",
-                "symfony/mailer": "^7.2.0",
-                "symfony/mime": "^7.2.0",
-                "symfony/polyfill-php83": "^1.33",
-                "symfony/polyfill-php84": "^1.33",
-                "symfony/polyfill-php85": "^1.33",
-                "symfony/process": "^7.2.0",
-                "symfony/routing": "^7.2.0",
-                "symfony/uid": "^7.2.0",
-                "symfony/var-dumper": "^7.2.0",
+                "symfony/console": "^7.4.0 || ^8.0.0",
+                "symfony/error-handler": "^7.4.0 || ^8.0.0",
+                "symfony/finder": "^7.4.0 || ^8.0.0",
+                "symfony/http-foundation": "^7.4.0 || ^8.0.0",
+                "symfony/http-kernel": "^7.4.0 || ^8.0.0",
+                "symfony/mailer": "^7.4.0 || ^8.0.0",
+                "symfony/mime": "^7.4.0 || ^8.0.0",
+                "symfony/polyfill-php84": "^1.36",
+                "symfony/polyfill-php85": "^1.36",
+                "symfony/polyfill-php86": "^1.36",
+                "symfony/process": "^7.4.5 || ^8.0.5",
+                "symfony/routing": "^7.4.0 || ^8.0.0",
+                "symfony/uid": "^7.4.0 || ^8.0.0",
+                "symfony/var-dumper": "^7.4.0 || ^8.0.0",
                 "tijsverkoyen/css-to-inline-styles": "^2.2.5",
                 "vlucas/phpdotenv": "^5.6.1",
                 "voku/portable-ascii": "^2.0.2"
@@ -1255,9 +1255,9 @@
                 "tightenco/collect": "<5.5.33"
             },
             "provide": {
-                "psr/container-implementation": "1.1|2.0",
-                "psr/log-implementation": "1.0|2.0|3.0",
-                "psr/simple-cache-implementation": "1.0|2.0|3.0"
+                "psr/container-implementation": "1.1 || 2.0",
+                "psr/log-implementation": "1.0 || 2.0 || 3.0",
+                "psr/simple-cache-implementation": "1.0 || 2.0 || 3.0"
             },
             "replace": {
                 "illuminate/auth": "self.version",
@@ -1303,8 +1303,7 @@
                 "aws/aws-sdk-php": "^3.322.9",
                 "ext-gmp": "*",
                 "fakerphp/faker": "^1.24",
-                "guzzlehttp/promises": "^2.0.3",
-                "guzzlehttp/psr7": "^2.4",
+                "guzzlehttp/psr7": "^2.9",
                 "laravel/pint": "^1.18",
                 "league/flysystem-aws-s3-v3": "^3.25.1",
                 "league/flysystem-ftp": "^3.25.1",
@@ -1313,22 +1312,23 @@
                 "league/flysystem-sftp-v3": "^3.25.1",
                 "mockery/mockery": "^1.6.10",
                 "opis/json-schema": "^2.4.1",
-                "orchestra/testbench-core": "^10.9.0",
-                "pda/pheanstalk": "^5.0.6|^7.0.0",
+                "orchestra/testbench-core": "^11.0.0",
+                "pda/pheanstalk": "^7.0.0 || ^8.0.0",
                 "php-http/discovery": "^1.15",
                 "phpstan/phpstan": "^2.0",
-                "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",
-                "predis/predis": "^2.3|^3.0",
-                "resend/resend-php": "^0.10.0|^1.0",
-                "symfony/cache": "^7.2.0",
-                "symfony/http-client": "^7.2.0",
-                "symfony/psr-http-message-bridge": "^7.2.0",
-                "symfony/translation": "^7.2.0"
+                "phpunit/phpunit": "^11.5.50 || ^12.5.8 || ^13.0.3",
+                "predis/predis": "^2.3 || ^3.0",
+                "rector/rector": "^2.3",
+                "resend/resend-php": "^1.0",
+                "symfony/cache": "^7.4.0 || ^8.0.0",
+                "symfony/http-client": "^7.4.0 || ^8.0.0",
+                "symfony/psr-http-message-bridge": "^7.4.0 || ^8.0.0",
+                "symfony/translation": "^7.4.0 || ^8.0.0"
             },
             "suggest": {
                 "ably/ably-php": "Required to use the Ably broadcast driver (^1.0).",
                 "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage, and SES mail driver (^3.322.9).",
-                "brianium/paratest": "Required to run tests in parallel (^7.0|^8.0).",
+                "brianium/paratest": "Required to run tests in parallel (^7.0 || ^8.0).",
                 "ext-apcu": "Required to use the APC cache driver.",
                 "ext-fileinfo": "Required to use the Filesystem class.",
                 "ext-ftp": "Required to use the Flysystem FTP driver.",
@@ -1337,7 +1337,7 @@
                 "ext-pcntl": "Required to use all features of the queue worker and console signal trapping.",
                 "ext-pdo": "Required to use all database features.",
                 "ext-posix": "Required to use all features of the queue worker.",
-                "ext-redis": "Required to use the Redis cache and queue drivers (^4.0|^5.0|^6.0).",
+                "ext-redis": "Required to use the Redis cache and queue drivers (^4.0 || ^5.0 || ^6.0).",
                 "fakerphp/faker": "Required to generate fake data using the fake() helper (^1.23).",
                 "filp/whoops": "Required for friendly error pages in development (^2.14.3).",
                 "laravel/tinker": "Required to use the tinker console command (^2.0).",
@@ -1347,25 +1347,25 @@
                 "league/flysystem-read-only": "Required to use read-only disks (^3.25.1)",
                 "league/flysystem-sftp-v3": "Required to use the Flysystem SFTP driver (^3.25.1).",
                 "mockery/mockery": "Required to use mocking (^1.6).",
-                "pda/pheanstalk": "Required to use the beanstalk queue driver (^5.0).",
+                "pda/pheanstalk": "Required to use the beanstalk queue driver (^7.0 || ^8.0).",
                 "php-http/discovery": "Required to use PSR-7 bridging features (^1.15).",
-                "phpunit/phpunit": "Required to use assertions and run tests (^10.5.35|^11.5.3|^12.0.1).",
-                "predis/predis": "Required to use the predis connector (^2.3|^3.0).",
+                "phpunit/phpunit": "Required to use assertions and run tests (^11.5.50 || ^12.5.8 || ^13.0.3).",
+                "predis/predis": "Required to use the predis connector (^2.3 || ^3.0).",
                 "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
-                "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0|^7.0).",
-                "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0|^1.0).",
-                "symfony/cache": "Required to PSR-6 cache bridge (^7.2).",
-                "symfony/filesystem": "Required to enable support for relative symbolic links (^7.2).",
-                "symfony/http-client": "Required to enable support for the Symfony API mail transports (^7.2).",
-                "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^7.2).",
-                "symfony/postmark-mailer": "Required to enable support for the Postmark mail transport (^7.2).",
-                "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^7.2)."
+                "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0 || ^7.0).",
+                "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0 || ^1.0).",
+                "spatie/fork": "Required to use the 'fork' concurrency driver (^1.2).",
+                "symfony/cache": "Required to PSR-6 cache bridge (^7.4 || ^8.0).",
+                "symfony/filesystem": "Required to enable support for relative symbolic links (^7.4 || ^8.0).",
+                "symfony/http-client": "Required to enable support for the Symfony API mail transports (^7.4 || ^8.0).",
+                "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^7.4 || ^8.0).",
+                "symfony/postmark-mailer": "Required to enable support for the Postmark mail transport (^7.4 || ^8.0).",
+                "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^7.4 || ^8.0)."
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "12.x-dev"
+                    "dev-master": "13.0.x-dev"
                 }
             },
             "autoload": {
@@ -1410,20 +1410,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-02-26T14:49:50+00:00"
+            "time": "2026-06-16T16:07:50+00:00"
         },
         {
             "name": "laravel/prompts",
-            "version": "dev-main",
+            "version": "v0.3.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "cbfdcf19160c0b6ef9fc7569fdbd360efeea5d51"
+                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/cbfdcf19160c0b6ef9fc7569fdbd360efeea5d51",
-                "reference": "cbfdcf19160c0b6ef9fc7569fdbd360efeea5d51",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/a19af51bb144bf87f08397921fa619f85c7d4e72",
+                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72",
                 "shasum": ""
             },
             "require": {
@@ -1446,7 +1446,6 @@
             "suggest": {
                 "ext-pcntl": "Required for the spinner to be animated."
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -1468,22 +1467,22 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/main"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.18"
             },
-            "time": "2026-02-10T18:44:26+00:00"
+            "time": "2026-05-19T00:47:18+00:00"
         },
         {
             "name": "laravel/serializable-closure",
-            "version": "2.x-dev",
+            "version": "v2.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/serializable-closure.git",
-                "reference": "92df8041c333e3feb9345184ed95e508a4ab00b0"
+                "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/92df8041c333e3feb9345184ed95e508a4ab00b0",
-                "reference": "92df8041c333e3feb9345184ed95e508a4ab00b0",
+                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
+                "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
                 "shasum": ""
             },
             "require": {
@@ -1496,7 +1495,6 @@
                 "phpstan/phpstan": "^2.0",
                 "symfony/var-dumper": "^6.2.0|^7.0.0|^8.0.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -1532,20 +1530,20 @@
                 "issues": "https://github.com/laravel/serializable-closure/issues",
                 "source": "https://github.com/laravel/serializable-closure"
             },
-            "time": "2026-02-24T14:45:45+00:00"
+            "time": "2026-04-16T14:03:50+00:00"
         },
         {
             "name": "league/commonmark",
-            "version": "dev-main",
+            "version": "2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "c915c1a26a30c6f256f0f6a0e2a5c27d95badca5"
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/c915c1a26a30c6f256f0f6a0e2a5c27d95badca5",
-                "reference": "c915c1a26a30c6f256f0f6a0e2a5c27d95badca5",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
                 "shasum": ""
             },
             "require": {
@@ -1570,9 +1568,9 @@
                 "phpstan/phpstan": "^1.8.2",
                 "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
                 "scrutinizer/ocular": "^1.8.1",
-                "symfony/finder": "^5.3 | ^6.0 | ^7.0",
-                "symfony/process": "^5.4 | ^6.0 | ^7.0",
-                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0",
+                "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0 || ^8.0",
                 "unleashedtech/php-coding-standard": "^3.1.1",
                 "vimeo/psalm": "^4.24.0 || ^5.0.0 || ^6.0.0"
             },
@@ -1639,20 +1637,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-12T12:38:57+00:00"
+            "time": "2026-03-19T13:16:38+00:00"
         },
         {
             "name": "league/config",
-            "version": "dev-main",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/config.git",
-                "reference": "af46987110f9c3aec257f06b0d77a8e97db2ef85"
+                "reference": "754b3604fb2984c71f4af4a9cbe7b57f346ec1f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/config/zipball/af46987110f9c3aec257f06b0d77a8e97db2ef85",
-                "reference": "af46987110f9c3aec257f06b0d77a8e97db2ef85",
+                "url": "https://api.github.com/repos/thephpleague/config/zipball/754b3604fb2984c71f4af4a9cbe7b57f346ec1f3",
+                "reference": "754b3604fb2984c71f4af4a9cbe7b57f346ec1f3",
                 "shasum": ""
             },
             "require": {
@@ -1662,12 +1660,11 @@
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.8.2",
-                "phpunit/phpunit": "^9.5.5 || ^10.0.0 || ^11.0.0",
+                "phpunit/phpunit": "^9.5.5",
                 "scrutinizer/ocular": "^1.8.1",
                 "unleashedtech/php-coding-standard": "^3.1",
                 "vimeo/psalm": "^4.7.3"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -1722,20 +1719,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-24T00:20:59+00:00"
+            "time": "2022-12-11T20:36:23+00:00"
         },
         {
             "name": "league/flysystem",
-            "version": "3.x-dev",
+            "version": "3.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "254b1595b16b22dbddaaef9ed6ca9fdac4956725"
+                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/254b1595b16b22dbddaaef9ed6ca9fdac4956725",
-                "reference": "254b1595b16b22dbddaaef9ed6ca9fdac4956725",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
+                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
                 "shasum": ""
             },
             "require": {
@@ -1771,7 +1768,6 @@
                 "phpunit/phpunit": "^9.5.11|^10.0",
                 "sabre/dav": "^4.6.0"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -1804,13 +1800,13 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.x"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.34.0"
             },
-            "time": "2026-02-25T17:01:41+00:00"
+            "time": "2026-05-14T10:28:08+00:00"
         },
         {
             "name": "league/flysystem-local",
-            "version": "3.x-dev",
+            "version": "3.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem-local.git",
@@ -1828,7 +1824,6 @@
                 "league/mime-type-detection": "^1.0.0",
                 "php": "^8.0.2"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -1854,7 +1849,7 @@
                 "local"
             ],
             "support": {
-                "source": "https://github.com/thephpleague/flysystem-local/tree/3.x"
+                "source": "https://github.com/thephpleague/flysystem-local/tree/3.31.0"
             },
             "time": "2026-01-23T15:30:45+00:00"
         },
@@ -1916,20 +1911,20 @@
         },
         {
             "name": "league/uri",
-            "version": "dev-master",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "13b9a7c0a7a8fdfc04848c2afc2350717a5800c1"
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/13b9a7c0a7a8fdfc04848c2afc2350717a5800c1",
-                "reference": "13b9a7c0a7a8fdfc04848c2afc2350717a5800c1",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
                 "shasum": ""
             },
             "require": {
-                "league/uri-interfaces": "^7.8",
+                "league/uri-interfaces": "^7.8.1",
                 "php": "^8.1",
                 "psr/http-factory": "^1"
             },
@@ -1950,7 +1945,6 @@
                 "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -2003,7 +1997,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/master"
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
             },
             "funding": [
                 {
@@ -2011,20 +2005,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-20T12:12:53+00:00"
+            "time": "2026-03-15T20:22:25+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "dev-master",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "c0855e4c1cbd9c105c59644fe7412c506c61e268"
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/c0855e4c1cbd9c105c59644fe7412c506c61e268",
-                "reference": "c0855e4c1cbd9c105c59644fe7412c506c61e268",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
                 "shasum": ""
             },
             "require": {
@@ -2040,7 +2034,6 @@
                 "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -2088,7 +2081,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/master"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
             },
             "funding": [
                 {
@@ -2096,7 +2089,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-20T12:33:44+00:00"
+            "time": "2026-03-08T20:05:35+00:00"
         },
         {
             "name": "maxmind-db/reader",
@@ -2215,16 +2208,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "dev-main",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "6db20ca029219dd8de378cea8e32ee149399ef1b"
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/6db20ca029219dd8de378cea8e32ee149399ef1b",
-                "reference": "6db20ca029219dd8de378cea8e32ee149399ef1b",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0",
                 "shasum": ""
             },
             "require": {
@@ -2271,7 +2264,6 @@
                 "rollbar/rollbar": "Allow sending log messages to Rollbar",
                 "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -2303,7 +2295,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/main"
+                "source": "https://github.com/Seldaek/monolog/tree/3.10.0"
             },
             "funding": [
                 {
@@ -2315,20 +2307,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-23T16:52:20+00:00"
+            "time": "2026-01-02T08:56:05+00:00"
         },
         {
             "name": "nesbot/carbon",
-            "version": "dev-master",
+            "version": "3.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "dd9bcbfa6e3df1246409f02935e6f80e02a7eb2a"
+                "reference": "6e7853a668c3107294aff38d42bf760ec02126b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/dd9bcbfa6e3df1246409f02935e6f80e02a7eb2a",
-                "reference": "dd9bcbfa6e3df1246409f02935e6f80e02a7eb2a",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/6e7853a668c3107294aff38d42bf760ec02126b6",
+                "reference": "6e7853a668c3107294aff38d42bf760ec02126b6",
                 "shasum": ""
             },
             "require": {
@@ -2354,7 +2346,6 @@
                 "phpunit/phpunit": "^10.5.53",
                 "squizlabs/php_codesniffer": "^3.13.4 || ^4.0.0"
             },
-            "default-branch": true,
             "bin": [
                 "bin/carbon"
             ],
@@ -2421,20 +2412,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T18:14:36+00:00"
+            "time": "2026-06-14T20:41:42+00:00"
         },
         {
             "name": "nette/schema",
-            "version": "v1.3.x-dev",
+            "version": "v1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "218e18c5d329c831a04e2fa5dd00656a8ba6ab2d"
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/218e18c5d329c831a04e2fa5dd00656a8ba6ab2d",
-                "reference": "218e18c5d329c831a04e2fa5dd00656a8ba6ab2d",
+                "url": "https://api.github.com/repos/nette/schema/zipball/f0ab1a3cda782dbc5da270d28545236aa80c4002",
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002",
                 "shasum": ""
             },
             "require": {
@@ -2486,22 +2477,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/schema/issues",
-                "source": "https://github.com/nette/schema/tree/v1.3"
+                "source": "https://github.com/nette/schema/tree/v1.3.5"
             },
             "time": "2026-02-23T03:47:12+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "dev-master",
+            "version": "v4.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "09f3c310ac056457c6bd73c45b71d517a08a1b51"
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/09f3c310ac056457c6bd73c45b71d517a08a1b51",
-                "reference": "09f3c310ac056457c6bd73c45b71d517a08a1b51",
+                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
                 "shasum": ""
             },
             "require": {
@@ -2527,7 +2518,6 @@
                 "ext-mbstring": "to use Strings::lower() etc...",
                 "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -2578,13 +2568,13 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/master"
+                "source": "https://github.com/nette/utils/tree/v4.1.4"
             },
-            "time": "2026-02-23T01:47:36+00:00"
+            "time": "2026-05-11T20:49:54+00:00"
         },
         {
             "name": "nunomaduro/termwind",
-            "version": "2.x-dev",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/termwind.git",
@@ -2611,7 +2601,6 @@
                 "symfony/var-dumper": "^7.3.5 || ^8.0.4",
                 "thecodingmachine/phpstan-strict-rules": "^1.0.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -2652,7 +2641,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nunomaduro/termwind/issues",
-                "source": "https://github.com/nunomaduro/termwind/tree/2.x"
+                "source": "https://github.com/nunomaduro/termwind/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -2672,16 +2661,16 @@
         },
         {
             "name": "phpoption/phpoption",
-            "version": "dev-master",
+            "version": "1.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "c7c576f3b1245ee34fad8904fa6478c443c8e0bc"
+                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/c7c576f3b1245ee34fad8904fa6478c443c8e0bc",
-                "reference": "c7c576f3b1245ee34fad8904fa6478c443c8e0bc",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/75365b91986c2405cf5e1e012c5595cd487a98be",
+                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be",
                 "shasum": ""
             },
             "require": {
@@ -2691,7 +2680,6 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "phpunit/phpunit": "^8.5.44 || ^9.6.25 || ^10.5.53 || ^11.5.34"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "bamarni-bin": {
@@ -2732,7 +2720,7 @@
             ],
             "support": {
                 "issues": "https://github.com/schmittjoh/php-option/issues",
-                "source": "https://github.com/schmittjoh/php-option/tree/master"
+                "source": "https://github.com/schmittjoh/php-option/tree/1.9.5"
             },
             "funding": [
                 {
@@ -2744,7 +2732,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-27T19:43:39+00:00"
+            "time": "2025-12-27T19:41:33+00:00"
         },
         {
             "name": "psr/clock",
@@ -2796,22 +2784,21 @@
         },
         {
             "name": "psr/container",
-            "version": "dev-master",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "707984727bd5b2b670e59559d3ed2500240cf875"
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/707984727bd5b2b670e59559d3ed2500240cf875",
-                "reference": "707984727bd5b2b670e59559d3ed2500240cf875",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -2844,31 +2831,27 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container"
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2023-09-22T11:11:30+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "psr/event-dispatcher",
-            "version": "dev-master",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/event-dispatcher.git",
-                "reference": "bbd9eacc080d33861e5b5c75b3b8c4d7e6d01874"
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/bbd9eacc080d33861e5b5c75b3b8c4d7e6d01874",
-                "reference": "bbd9eacc080d33861e5b5c75b3b8c4d7e6d01874",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.0"
             },
-            "suggest": {
-                "fig/event-dispatcher-util": "Provides some useful PSR-14 utilities"
-            },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -2887,7 +2870,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
+                    "homepage": "http://www.php-fig.org/"
                 }
             ],
             "description": "Standard interfaces for event handling.",
@@ -2897,13 +2880,14 @@
                 "psr-14"
             ],
             "support": {
-                "source": "https://github.com/php-fig/event-dispatcher"
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
-            "time": "2024-03-17T21:29:03+00:00"
+            "time": "2019-01-08T18:20:26+00:00"
         },
         {
             "name": "psr/http-client",
-            "version": "dev-master",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-client.git",
@@ -2919,7 +2903,6 @@
                 "php": "^7.0 || ^8.0",
                 "psr/http-message": "^1.0 || ^2.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -3011,7 +2994,7 @@
         },
         {
             "name": "psr/http-message",
-            "version": "dev-master",
+            "version": "2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
@@ -3026,7 +3009,6 @@
             "require": {
                 "php": "^7.2 || ^8.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -3065,7 +3047,7 @@
         },
         {
             "name": "psr/log",
-            "version": "dev-master",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
@@ -3080,7 +3062,6 @@
             "require": {
                 "php": ">=8.0.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -3116,22 +3097,21 @@
         },
         {
             "name": "psr/simple-cache",
-            "version": "dev-master",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "2d280c2aaa23a120f35d55cfde8581954a8e77fa"
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/2d280c2aaa23a120f35d55cfde8581954a8e77fa",
-                "reference": "2d280c2aaa23a120f35d55cfde8581954a8e77fa",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -3162,9 +3142,9 @@
                 "simple-cache"
             ],
             "support": {
-                "source": "https://github.com/php-fig/simple-cache/tree/master"
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
             },
-            "time": "2022-04-08T16:41:45+00:00"
+            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -3288,7 +3268,7 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.x-dev",
+            "version": "4.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
@@ -3334,7 +3314,6 @@
                 "paragonie/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
                 "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "captainhook": {
@@ -3367,16 +3346,16 @@
         },
         {
             "name": "stevebauman/location",
-            "version": "v7.6.2",
+            "version": "v7.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stevebauman/location.git",
-                "reference": "2f7686b685b924f193d6a6b82074861b8cc5aa3a"
+                "reference": "ed76d047c40dc13646438e486a8981102476adbe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stevebauman/location/zipball/2f7686b685b924f193d6a6b82074861b8cc5aa3a",
-                "reference": "2f7686b685b924f193d6a6b82074861b8cc5aa3a",
+                "url": "https://api.github.com/repos/stevebauman/location/zipball/ed76d047c40dc13646438e486a8981102476adbe",
+                "reference": "ed76d047c40dc13646438e486a8981102476adbe",
                 "shasum": ""
             },
             "require": {
@@ -3384,12 +3363,12 @@
                 "ext-json": "*",
                 "geoip2/geoip2": "^2.0|^3.0",
                 "guzzlehttp/guzzle": "^7.0",
-                "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
                 "php": ">=8.1"
             },
             "require-dev": {
                 "mockery/mockery": "^1.0",
-                "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0",
+                "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
                 "pestphp/pest": "^1.0|^2.0|^3.7"
             },
             "type": "library",
@@ -3430,32 +3409,31 @@
             ],
             "support": {
                 "issues": "https://github.com/stevebauman/location/issues",
-                "source": "https://github.com/stevebauman/location/tree/v7.6.2"
+                "source": "https://github.com/stevebauman/location/tree/v7.6.3"
             },
-            "time": "2026-02-11T16:06:17+00:00"
+            "time": "2026-03-18T16:51:48+00:00"
         },
         {
             "name": "symfony/clock",
-            "version": "8.1.x-dev",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "832119f9b8dbc6c8e6f65f30c5969eca1e88764f"
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/832119f9b8dbc6c8e6f65f30c5969eca1e88764f",
-                "reference": "832119f9b8dbc6c8e6f65f30c5969eca1e88764f",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/701ef4de9705d6c32292ebee5e8044094a09fbf6",
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "psr/clock": "^1.0"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "files": [
@@ -3490,7 +3468,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v8.0.0-RC1"
+                "source": "https://github.com/symfony/clock/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -3510,51 +3488,53 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-12T15:46:48+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "7.4.x-dev",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6d643a93b47398599124022eb24d97c153c12f27"
+                "reference": "f5a856c6ecb56b3c21ed94a5b7bf940d857d110a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6d643a93b47398599124022eb24d97c153c12f27",
-                "reference": "6d643a93b47398599124022eb24d97c153c12f27",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f5a856c6ecb56b3c21ed94a5b7bf940d857d110a",
+                "reference": "f5a856c6ecb56b3c21ed94a5b7bf940d857d110a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4.1",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/polyfill-php85": "^1.32",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^7.2|^8.0"
+                "symfony/string": "^7.4.6|^8.0.6"
             },
             "conflict": {
-                "symfony/dependency-injection": "<6.4",
-                "symfony/dotenv": "<6.4",
-                "symfony/event-dispatcher": "<6.4",
-                "symfony/lock": "<6.4",
-                "symfony/process": "<6.4"
+                "symfony/dependency-injection": "<8.1",
+                "symfony/event-dispatcher": "<8.1"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/lock": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^8.1",
+                "symfony/event-dispatcher": "^8.1",
+                "symfony/filesystem": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/mime": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/uid": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3588,7 +3568,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/7.4"
+                "source": "https://github.com/symfony/console/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -3608,26 +3588,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T17:02:47+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "8.1.x-dev",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "f7c24bbef3be1d910223f98d757e7792d66a44c1"
+                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/f7c24bbef3be1d910223f98d757e7792d66a44c1",
-                "reference": "f7c24bbef3be1d910223f98d757e7792d66a44c1",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/dc0e2be45c9b5588c82414f02ac574b4b986abcd",
+                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4"
+                "php": ">=8.4.1"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -3658,7 +3637,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/8.1"
+                "source": "https://github.com/symfony/css-selector/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -3678,26 +3657,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-17T13:08:34+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "dev-main",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "bbd66f9d55454b9b7a66a9cebe77523806a3288a"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/bbd66f9d55454b9b7a66a9cebe77523806a3288a",
-                "reference": "bbd66f9d55454b9b7a66a9cebe77523806a3288a",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "thanks": {
@@ -3730,7 +3708,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/main"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -3750,37 +3728,36 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T13:30:16+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "7.4.x-dev",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "8da531f364ddfee53e36092a7eebbbd0b775f6b8"
+                "reference": "d8aeb1abd3fef84795567850d3a567bdb5945ee5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/8da531f364ddfee53e36092a7eebbbd0b775f6b8",
-                "reference": "8da531f364ddfee53e36092a7eebbbd0b775f6b8",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/d8aeb1abd3fef84795567850d3a567bdb5945ee5",
+                "reference": "d8aeb1abd3fef84795567850d3a567bdb5945ee5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4.1",
                 "psr/log": "^1|^2|^3",
                 "symfony/polyfill-php85": "^1.32",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "conflict": {
-                "symfony/deprecation-contracts": "<2.5",
-                "symfony/http-kernel": "<6.4"
+                "symfony/deprecation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/console": "^7.4|^8.0",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0",
                 "symfony/webpack-encore-bundle": "^1.0|^2.0"
             },
             "bin": [
@@ -3812,7 +3789,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/7.4"
+                "source": "https://github.com/symfony/error-handler/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -3832,24 +3809,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-20T16:42:42+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "8.1.x-dev",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "bd57b0a5c68c9a59f3f7c71583f0829110feee5d"
+                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/bd57b0a5c68c9a59f3f7c71583f0829110feee5d",
-                "reference": "bd57b0a5c68c9a59f3f7c71583f0829110feee5d",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f249ae3f680958b6f1f9dd76e5747cf0695b4102",
+                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
@@ -3871,7 +3849,6 @@
                 "symfony/service-contracts": "^2.5|^3",
                 "symfony/stopwatch": "^7.4|^8.0"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -3898,7 +3875,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/8.1"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -3918,11 +3895,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-14T14:51:52+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "dev-main",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
@@ -3938,7 +3915,6 @@
                 "php": ">=8.1",
                 "psr/event-dispatcher": "^1"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "thanks": {
@@ -3979,7 +3955,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/main"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -4003,23 +3979,23 @@
         },
         {
             "name": "symfony/finder",
-            "version": "7.4.x-dev",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "8655bf1076b7a3a346cb11413ffdabff50c7ffcf"
+                "reference": "58d2e767a66052c1487356f953445634a8194c64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/8655bf1076b7a3a346cb11413ffdabff50c7ffcf",
-                "reference": "8655bf1076b7a3a346cb11413ffdabff50c7ffcf",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/58d2e767a66052c1487356f953445634a8194c64",
+                "reference": "58d2e767a66052c1487356f953445634a8194c64",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4.1"
             },
             "require-dev": {
-                "symfony/filesystem": "^6.4|^7.0|^8.0"
+                "symfony/filesystem": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4047,7 +4023,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/7.4"
+                "source": "https://github.com/symfony/finder/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -4067,41 +4043,40 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-29T09:40:50+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "7.4.x-dev",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "fd97d5e926e988a363cef56fbbf88c5c528e9065"
+                "reference": "af11474600f06718086c2cda4fa6fa8d0a672e7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/fd97d5e926e988a363cef56fbbf88c5c528e9065",
-                "reference": "fd97d5e926e988a363cef56fbbf88c5c528e9065",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/af11474600f06718086c2cda4fa6fa8d0a672e7e",
+                "reference": "af11474600f06718086c2cda4fa6fa8d0a672e7e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4.1",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "^1.1"
             },
             "conflict": {
-                "doctrine/dbal": "<3.6",
-                "symfony/cache": "<6.4.12|>=7.0,<7.1.5"
+                "doctrine/dbal": "<4.3"
             },
             "require-dev": {
-                "doctrine/dbal": "^3.6|^4",
+                "doctrine/dbal": "^4.3",
                 "predis/predis": "^1.1|^2.0",
-                "symfony/cache": "^6.4.12|^7.1.5|^8.0",
-                "symfony/clock": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/mime": "^6.4|^7.0|^8.0",
-                "symfony/rate-limiter": "^6.4|^7.0|^8.0"
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/clock": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/mime": "^7.4|^8.0",
+                "symfony/rate-limiter": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4129,7 +4104,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/7.4"
+                "source": "https://github.com/symfony/http-foundation/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -4149,78 +4124,68 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-21T16:25:55+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "7.4.x-dev",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "ba2ab571fcc06ba443a62773f427e01a54e2a925"
+                "reference": "cefeb37c82eed3e0c42fa25ba64cd3a908d90f39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/ba2ab571fcc06ba443a62773f427e01a54e2a925",
-                "reference": "ba2ab571fcc06ba443a62773f427e01a54e2a925",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/cefeb37c82eed3e0c42fa25ba64cd3a908d90f39",
+                "reference": "cefeb37c82eed3e0c42fa25ba64cd3a908d90f39",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4.1",
                 "psr/log": "^1|^2|^3",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/error-handler": "^6.4|^7.0|^8.0",
-                "symfony/event-dispatcher": "^7.3|^8.0",
+                "symfony/error-handler": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
                 "symfony/http-foundation": "^7.4|^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/browser-kit": "<6.4",
-                "symfony/cache": "<6.4",
-                "symfony/config": "<6.4",
-                "symfony/console": "<6.4",
-                "symfony/dependency-injection": "<6.4",
-                "symfony/doctrine-bridge": "<6.4",
+                "symfony/dependency-injection": "<8.1",
                 "symfony/flex": "<2.10",
-                "symfony/form": "<6.4",
-                "symfony/http-client": "<6.4",
                 "symfony/http-client-contracts": "<2.5",
-                "symfony/mailer": "<6.4",
-                "symfony/messenger": "<6.4",
-                "symfony/translation": "<6.4",
                 "symfony/translation-contracts": "<2.5",
-                "symfony/twig-bridge": "<6.4",
-                "symfony/validator": "<6.4",
-                "symfony/var-dumper": "<6.4",
-                "twig/twig": "<3.12"
+                "symfony/var-dumper": "<8.1",
+                "symfony/web-profiler-bundle": "<8.1",
+                "twig/twig": "<3.21"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/cache": "^1.0|^2.0|^3.0",
-                "symfony/browser-kit": "^6.4|^7.0|^8.0",
-                "symfony/clock": "^6.4|^7.0|^8.0",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/css-selector": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4.1|^7.0.1|^8.0",
-                "symfony/dom-crawler": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/browser-kit": "^7.4|^8.0",
+                "symfony/clock": "^7.4|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/css-selector": "^7.4|^8.0",
+                "symfony/dependency-injection": "^8.1",
+                "symfony/dom-crawler": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
                 "symfony/http-client-contracts": "^2.5|^3",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/property-access": "^7.1|^8.0",
-                "symfony/routing": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^7.1|^8.0",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/translation": "^6.4|^7.0|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/rate-limiter": "^7.4|^8.0",
+                "symfony/routing": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/translation": "^7.4|^8.0",
                 "symfony/translation-contracts": "^2.5|^3",
-                "symfony/uid": "^6.4|^7.0|^8.0",
-                "symfony/validator": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0",
-                "symfony/var-exporter": "^6.4|^7.0|^8.0",
-                "twig/twig": "^3.12"
+                "symfony/uid": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0",
+                "symfony/var-dumper": "^8.1",
+                "symfony/var-exporter": "^7.4|^8.0",
+                "twig/twig": "^3.21"
             },
             "type": "library",
             "autoload": {
@@ -4248,7 +4213,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/7.4"
+                "source": "https://github.com/symfony/http-kernel/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -4268,43 +4233,39 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-26T08:31:35+00:00"
+            "time": "2026-05-29T08:46:08+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "7.4.x-dev",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "b02726f39a20bc65e30364f5c750c4ddbf1f58e9"
+                "reference": "9418d772df3a03a142e3bc06f602adb2b8724877"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/b02726f39a20bc65e30364f5c750c4ddbf1f58e9",
-                "reference": "b02726f39a20bc65e30364f5c750c4ddbf1f58e9",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/9418d772df3a03a142e3bc06f602adb2b8724877",
+                "reference": "9418d772df3a03a142e3bc06f602adb2b8724877",
                 "shasum": ""
             },
             "require": {
                 "egulias/email-validator": "^2.1.10|^3|^4",
-                "php": ">=8.2",
+                "php": ">=8.4.1",
                 "psr/event-dispatcher": "^1",
                 "psr/log": "^1|^2|^3",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/mime": "^7.2|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/mime": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/http-client-contracts": "<2.5",
-                "symfony/http-kernel": "<6.4",
-                "symfony/messenger": "<6.4",
-                "symfony/mime": "<6.4",
-                "symfony/twig-bridge": "<6.4"
+                "symfony/http-client-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/http-client": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/twig-bridge": "^6.4|^7.0|^8.0"
+                "symfony/console": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/twig-bridge": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4332,7 +4293,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/7.4"
+                "source": "https://github.com/symfony/mailer/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -4352,44 +4313,41 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:50:00+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "7.4.x-dev",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "9fc881d95feae4c6c48678cb6372bd8a7ba04f5f"
+                "reference": "b164ae7e3f7915aacfe9ee155f2f358502440664"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/9fc881d95feae4c6c48678cb6372bd8a7ba04f5f",
-                "reference": "9fc881d95feae4c6c48678cb6372bd8a7ba04f5f",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/b164ae7e3f7915aacfe9ee155f2f358502440664",
+                "reference": "b164ae7e3f7915aacfe9ee155f2f358502440664",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.4.1",
                 "symfony/polyfill-intl-idn": "^1.10",
                 "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
                 "egulias/email-validator": "~3.0.0",
                 "phpdocumentor/reflection-docblock": "<5.2|>=7",
-                "phpdocumentor/type-resolver": "<1.5.1",
-                "symfony/mailer": "<6.4",
-                "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
+                "phpdocumentor/type-resolver": "<1.5.1"
             },
             "require-dev": {
                 "egulias/email-validator": "^2.1.10|^3.1|^4",
                 "league/html-to-markdown": "^5.0",
                 "phpdocumentor/reflection-docblock": "^5.2|^6.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/property-access": "^6.4|^7.0|^8.0",
-                "symfony/property-info": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^6.4.3|^7.0.3|^8.0"
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/property-info": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4421,7 +4379,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/7.4"
+                "source": "https://github.com/symfony/mime/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -4441,20 +4399,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-05T15:57:06+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "1.x-dev",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -4466,7 +4424,6 @@
             "suggest": {
                 "ext-ctype": "For best performance"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "thanks": {
@@ -4505,7 +4462,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -4525,20 +4482,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "1.x-dev",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -4547,7 +4504,6 @@
             "suggest": {
                 "ext-intl": "For best performance"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "thanks": {
@@ -4588,7 +4544,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4608,20 +4564,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "1.x-dev",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
                 "shasum": ""
             },
             "require": {
@@ -4631,7 +4587,6 @@
             "suggest": {
                 "ext-intl": "For best performance"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "thanks": {
@@ -4676,7 +4631,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4696,20 +4651,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-10T14:38:51+00:00"
+            "time": "2026-05-25T15:22:23+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "1.x-dev",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -4718,7 +4673,6 @@
             "suggest": {
                 "ext-intl": "For best performance"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "thanks": {
@@ -4762,7 +4716,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -4782,20 +4736,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "1.x-dev",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -4808,7 +4762,6 @@
             "suggest": {
                 "ext-mbstring": "For best performance"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "thanks": {
@@ -4848,7 +4801,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -4868,26 +4821,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "1.x-dev",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "thanks": {
@@ -4933,7 +4885,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -4953,107 +4905,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-02T08:10:11+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php83",
-            "version": "1.x-dev",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "default-branch": true,
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php83\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.3+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-07-08T02:45:35+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "1.x-dev",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "4acd8b3205f17b5811d5e036e89690fe8baad365"
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/4acd8b3205f17b5811d5e036e89690fe8baad365",
-                "reference": "4acd8b3205f17b5811d5e036e89690fe8baad365",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "thanks": {
@@ -5095,7 +4965,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/1.x"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -5115,26 +4985,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-20T10:44:59+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php85",
-            "version": "1.x-dev",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php85.git",
-                "reference": "65345afb52bf45a3d996295b3504ace5db1be853"
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/65345afb52bf45a3d996295b3504ace5db1be853",
-                "reference": "65345afb52bf45a3d996295b3504ace5db1be853",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "thanks": {
@@ -5176,7 +5045,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/1.x"
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -5196,20 +5065,100 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-20T10:49:54+00:00"
+            "time": "2026-05-26T02:25:22+00:00"
         },
         {
-            "name": "symfony/polyfill-uuid",
-            "version": "1.x-dev",
+            "name": "symfony/polyfill-php86",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-uuid.git",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2"
+                "url": "https://github.com/symfony/polyfill-php86.git",
+                "reference": "fcec68d64f46dc84e1f6ffcf2c6dda40ff3143ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php86/zipball/fcec68d64f46dc84e1f6ffcf2c6dda40ff3143ad",
+                "reference": "fcec68d64f46dc84e1f6ffcf2c6dda40ff3143ad",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php86\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.6+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php86/tree/v1.38.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T11:52:35+00:00"
+        },
+        {
+            "name": "symfony/polyfill-uuid",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-uuid.git",
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
                 "shasum": ""
             },
             "require": {
@@ -5221,7 +5170,6 @@
             "suggest": {
                 "ext-uuid": "For best performance"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "thanks": {
@@ -5260,7 +5208,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5280,24 +5228,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "7.4.x-dev",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "608476f4604102976d687c483ac63a79ba18cc97"
+                "reference": "c4a9e58f235a6bf7f97ffbfedae2687353ac79e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/608476f4604102976d687c483ac63a79ba18cc97",
-                "reference": "608476f4604102976d687c483ac63a79ba18cc97",
+                "url": "https://api.github.com/repos/symfony/process/zipball/c4a9e58f235a6bf7f97ffbfedae2687353ac79e5",
+                "reference": "c4a9e58f235a6bf7f97ffbfedae2687353ac79e5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4.1"
             },
             "type": "library",
             "autoload": {
@@ -5325,7 +5273,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/7.4"
+                "source": "https://github.com/symfony/process/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -5345,38 +5293,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-26T15:07:59+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "7.4.x-dev",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "238d749c56b804b31a9bf3e26519d93b65a60938"
+                "reference": "fe0bfec72c8a806109fb9c3a5f2b898fe0c76eb3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/238d749c56b804b31a9bf3e26519d93b65a60938",
-                "reference": "238d749c56b804b31a9bf3e26519d93b65a60938",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/fe0bfec72c8a806109fb9c3a5f2b898fe0c76eb3",
+                "reference": "fe0bfec72c8a806109fb9c3a5f2b898fe0c76eb3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4.1",
                 "symfony/deprecation-contracts": "^2.5|^3"
-            },
-            "conflict": {
-                "symfony/config": "<6.4",
-                "symfony/dependency-injection": "<6.4",
-                "symfony/yaml": "<6.4"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/yaml": "^6.4|^7.0|^8.0"
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5410,7 +5353,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/7.4"
+                "source": "https://github.com/symfony/routing/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -5430,20 +5373,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:50:00+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "dev-main",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "639fa48ea277babeb67e1432ce60a029d795bd63"
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/639fa48ea277babeb67e1432ce60a029d795bd63",
-                "reference": "639fa48ea277babeb67e1432ce60a029d795bd63",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
                 "shasum": ""
             },
             "require": {
@@ -5454,7 +5397,6 @@
             "conflict": {
                 "ext-psr": "<1.1|>=2"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "thanks": {
@@ -5498,7 +5440,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/main"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -5518,24 +5460,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-13T20:42:21+00:00"
+            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "8.1.x-dev",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "38ef56ae8e4d5ada76d807638689f135059dc648"
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/38ef56ae8e4d5ada76d807638689f135059dc648",
-                "reference": "38ef56ae8e4d5ada76d807638689f135059dc648",
+                "url": "https://api.github.com/repos/symfony/string/zipball/afd5944f4005862d961efb85c8bbd5c523c4e3c9",
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-intl-grapheme": "^1.33",
                 "symfony/polyfill-intl-normalizer": "^1.0",
@@ -5551,7 +5493,6 @@
                 "symfony/translation-contracts": "^2.5|^3.0",
                 "symfony/var-exporter": "^7.4|^8.0"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "files": [
@@ -5589,7 +5530,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/8.1"
+                "source": "https://github.com/symfony/string/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -5609,24 +5550,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-09T10:17:21+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "8.1.x-dev",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "ba0bc436a49eca3d8c7019eb41e05dd07f13742c"
+                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/ba0bc436a49eca3d8c7019eb41e05dd07f13742c",
-                "reference": "ba0bc436a49eca3d8c7019eb41e05dd07f13742c",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/b2bd012ca28c4acae830ee1206a5b6e35dd99693",
+                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "symfony/polyfill-mbstring": "^1.0",
                 "symfony/translation-contracts": "^3.6.1"
             },
@@ -5653,7 +5594,6 @@
                 "symfony/service-contracts": "^2.5|^3",
                 "symfony/yaml": "^7.4|^8.0"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "files": [
@@ -5683,7 +5623,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/8.1"
+                "source": "https://github.com/symfony/translation/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -5703,11 +5643,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T07:51:47+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "dev-main",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
@@ -5722,7 +5662,6 @@
             "require": {
                 "php": ">=8.1"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "thanks": {
@@ -5766,7 +5705,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/main"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -5790,24 +5729,24 @@
         },
         {
             "name": "symfony/uid",
-            "version": "7.4.x-dev",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/uid.git",
-                "reference": "7719ce8aba76be93dfe249192f1fbfa52c588e36"
+                "reference": "7393f157a55f7e70a4de0334435c55a5a8fe749a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/7719ce8aba76be93dfe249192f1fbfa52c588e36",
-                "reference": "7719ce8aba76be93dfe249192f1fbfa52c588e36",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/7393f157a55f7e70a4de0334435c55a5a8fe749a",
+                "reference": "7393f157a55f7e70a4de0334435c55a5a8fe749a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4.1",
                 "symfony/polyfill-uuid": "^1.15"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0"
+                "symfony/console": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5844,7 +5783,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/uid/tree/7.4"
+                "source": "https://github.com/symfony/uid/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -5864,35 +5803,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-03T23:30:35+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "7.4.x-dev",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "045321c440ac18347b136c63d2e9bf28a2dc0291"
+                "reference": "c2c4df1d21477cc21c9f6dc1b14d07c3abc4963e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/045321c440ac18347b136c63d2e9bf28a2dc0291",
-                "reference": "045321c440ac18347b136c63d2e9bf28a2dc0291",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/c2c4df1d21477cc21c9f6dc1b14d07c3abc4963e",
+                "reference": "c2c4df1d21477cc21c9f6dc1b14d07c3abc4963e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=8.4.1",
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
-                "symfony/console": "<6.4"
+                "symfony/console": "<7.4",
+                "symfony/error-handler": "<7.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/uid": "^6.4|^7.0|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/uid": "^7.4|^8.0",
                 "twig/twig": "^3.12"
             },
             "bin": [
@@ -5931,7 +5870,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/7.4"
+                "source": "https://github.com/symfony/var-dumper/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -5951,20 +5890,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-15T10:53:20+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
-            "version": "dev-master",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tijsverkoyen/CssToInlineStyles.git",
-                "reference": "a0aef6022b3d84b8c72855ded8581458d82d5013"
+                "reference": "f0292ccf0ec75843d65027214426b6b163b48b41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/a0aef6022b3d84b8c72855ded8581458d82d5013",
-                "reference": "a0aef6022b3d84b8c72855ded8581458d82d5013",
+                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/f0292ccf0ec75843d65027214426b6b163b48b41",
+                "reference": "f0292ccf0ec75843d65027214426b6b163b48b41",
                 "shasum": ""
             },
             "require": {
@@ -5978,7 +5917,6 @@
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^8.5.21 || ^9.5.10"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -6005,22 +5943,22 @@
             "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
             "support": {
                 "issues": "https://github.com/tijsverkoyen/CssToInlineStyles/issues",
-                "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/master"
+                "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/v2.4.0"
             },
-            "time": "2026-01-06T09:50:27+00:00"
+            "time": "2025-12-02T11:56:42+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "dev-master",
+            "version": "v5.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "2af27192fc6c6bf7c05ef26e67d54afe9a0c39e1"
+                "reference": "955e7815d677a3eaa7075231212f2110983adecc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/2af27192fc6c6bf7c05ef26e67d54afe9a0c39e1",
-                "reference": "2af27192fc6c6bf7c05ef26e67d54afe9a0c39e1",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/955e7815d677a3eaa7075231212f2110983adecc",
+                "reference": "955e7815d677a3eaa7075231212f2110983adecc",
                 "shasum": ""
             },
             "require": {
@@ -6040,7 +5978,6 @@
             "suggest": {
                 "ext-filter": "Required to use the boolean validator."
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "bamarni-bin": {
@@ -6080,7 +6017,7 @@
             ],
             "support": {
                 "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/master"
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.3"
             },
             "funding": [
                 {
@@ -6092,27 +6029,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-27T19:51:34+00:00"
+            "time": "2025-12-27T19:49:13+00:00"
         },
         {
             "name": "voku/portable-ascii",
-            "version": "2.0.3",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-ascii.git",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d"
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/8e1051fe39379367aecf014f41744ce7539a856f",
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
+                "phpunit/phpunit": "~8.5 || ~9.6 || ~10.5 || ~11.5"
             },
             "suggest": {
                 "ext-intl": "Use Intl for transliterator_transliterate() support"
@@ -6142,7 +6079,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/portable-ascii/issues",
-                "source": "https://github.com/voku/portable-ascii/tree/2.0.3"
+                "source": "https://github.com/voku/portable-ascii/tree/2.1.1"
             },
             "funding": [
                 {
@@ -6166,22 +6103,22 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-21T01:49:47+00:00"
+            "time": "2026-04-26T05:33:54+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "composer/semver",
-            "version": "dev-main",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "38ccbbfd0098b205e4d947f18e3f1f321803b067"
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/38ccbbfd0098b205e4d947f18e3f1f321803b067",
-                "reference": "38ccbbfd0098b205e4d947f18e3f1f321803b067",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
                 "shasum": ""
             },
             "require": {
@@ -6191,7 +6128,6 @@
                 "phpstan/phpstan": "^1.11",
                 "symfony/phpunit-bridge": "^3 || ^7"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -6224,7 +6160,7 @@
                     "homepage": "http://robbast.nl"
                 }
             ],
-            "description": "Version comparison library that offers utilities, version constraint parsing and validation.",
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
             "keywords": [
                 "semantic",
                 "semver",
@@ -6234,7 +6170,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/main"
+                "source": "https://github.com/composer/semver/tree/3.4.4"
             },
             "funding": [
                 {
@@ -6246,20 +6182,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-03T10:22:06+00:00"
+            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "fakerphp/faker",
-            "version": "1.24.x-dev",
+            "version": "v1.24.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FakerPHP/Faker.git",
-                "reference": "33d986d1bdc849f28543167fb568cb817a562891"
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/33d986d1bdc849f28543167fb568cb817a562891",
-                "reference": "33d986d1bdc849f28543167fb568cb817a562891",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
                 "shasum": ""
             },
             "require": {
@@ -6307,9 +6243,9 @@
             ],
             "support": {
                 "issues": "https://github.com/FakerPHP/Faker/issues",
-                "source": "https://github.com/FakerPHP/Faker/tree/1.24"
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
             },
-            "time": "2025-12-30T14:39:14+00:00"
+            "time": "2024-11-21T13:46:39+00:00"
         },
         {
             "name": "filp/whoops",
@@ -6435,16 +6371,16 @@
         },
         {
             "name": "laravel/pail",
-            "version": "dev-main",
+            "version": "v1.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pail.git",
-                "reference": "1adb023f647d86c7ec22b84b7b4c2b00ad1f7f73"
+                "reference": "2f7d27dada8effc48b8c424445a69cca7007daaa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pail/zipball/1adb023f647d86c7ec22b84b7b4c2b00ad1f7f73",
-                "reference": "1adb023f647d86c7ec22b84b7b4c2b00ad1f7f73",
+                "url": "https://api.github.com/repos/laravel/pail/zipball/2f7d27dada8effc48b8c424445a69cca7007daaa",
+                "reference": "2f7d27dada8effc48b8c424445a69cca7007daaa",
                 "shasum": ""
             },
             "require": {
@@ -6468,7 +6404,6 @@
                 "symfony/var-dumper": "^6.3|^7.0|^8.0",
                 "symfony/yaml": "^6.3|^7.0|^8.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -6512,20 +6447,20 @@
                 "issues": "https://github.com/laravel/pail/issues",
                 "source": "https://github.com/laravel/pail"
             },
-            "time": "2026-02-10T18:43:12+00:00"
+            "time": "2026-05-20T22:24:57+00:00"
         },
         {
             "name": "laravel/pint",
-            "version": "v1.27.1",
+            "version": "v1.29.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "54cca2de13790570c7b6f0f94f37896bee4abcb5"
+                "reference": "da1d1111a6aa2e082d2a388b194afe1ba0a05d14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/54cca2de13790570c7b6f0f94f37896bee4abcb5",
-                "reference": "54cca2de13790570c7b6f0f94f37896bee4abcb5",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/da1d1111a6aa2e082d2a388b194afe1ba0a05d14",
+                "reference": "da1d1111a6aa2e082d2a388b194afe1ba0a05d14",
                 "shasum": ""
             },
             "require": {
@@ -6536,13 +6471,14 @@
                 "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.93.1",
-                "illuminate/view": "^12.51.0",
-                "larastan/larastan": "^3.9.2",
-                "laravel-zero/framework": "^12.0.5",
+                "friendsofphp/php-cs-fixer": "^3.95.8",
+                "illuminate/view": "^12.62.0",
+                "larastan/larastan": "^3.10.0",
+                "laravel-zero/framework": "^12.1.0",
+                "laravel/agent-detector": "^2.0.2",
                 "mockery/mockery": "^1.6.12",
-                "nunomaduro/termwind": "^2.3.3",
-                "pestphp/pest": "^3.8.5"
+                "nunomaduro/termwind": "^2.4.0",
+                "pestphp/pest": "^3.8.6"
             },
             "bin": [
                 "builds/pint"
@@ -6579,45 +6515,47 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2026-02-10T20:00:20+00:00"
+            "time": "2026-06-16T15:34:04+00:00"
         },
         {
             "name": "laravel/tinker",
-            "version": "2.x-dev",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/tinker.git",
-                "reference": "eaa762692fda3c8b7caae5121897adf85d94ca33"
+                "reference": "4faba77764bd33411735936acdf30446d058c78b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/tinker/zipball/eaa762692fda3c8b7caae5121897adf85d94ca33",
-                "reference": "eaa762692fda3c8b7caae5121897adf85d94ca33",
+                "url": "https://api.github.com/repos/laravel/tinker/zipball/4faba77764bd33411735936acdf30446d058c78b",
+                "reference": "4faba77764bd33411735936acdf30446d058c78b",
                 "shasum": ""
             },
             "require": {
-                "illuminate/console": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-                "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-                "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-                "php": "^7.2.5|^8.0",
-                "psy/psysh": "^0.11.1|^0.12.0",
-                "symfony/var-dumper": "^4.3.4|^5.0|^6.0|^7.0|^8.0"
+                "illuminate/console": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.1",
+                "psy/psysh": "^0.12.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0|^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "~1.3.3|^1.4.2",
                 "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^8.5.8|^9.3.3|^10.0"
+                "phpunit/phpunit": "^10.5|^11.5"
             },
             "suggest": {
-                "illuminate/database": "The Illuminate Database package (^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0)."
+                "illuminate/database": "The Illuminate Database package (^8.0|^9.0|^10.0|^11.0|^12.0|^13.0)."
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
                     "providers": [
                         "Laravel\\Tinker\\TinkerServiceProvider"
                     ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
@@ -6644,22 +6582,22 @@
             ],
             "support": {
                 "issues": "https://github.com/laravel/tinker/issues",
-                "source": "https://github.com/laravel/tinker/tree/2.x"
+                "source": "https://github.com/laravel/tinker/tree/v3.0.2"
             },
-            "time": "2026-02-10T18:46:04+00:00"
+            "time": "2026-03-17T14:54:13+00:00"
         },
         {
             "name": "mockery/mockery",
-            "version": "1.7.x-dev",
+            "version": "1.6.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "3f8d3ff1ffe4c552d45c5690c6d825e9310769bf"
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/3f8d3ff1ffe4c552d45c5690c6d825e9310769bf",
-                "reference": "3f8d3ff1ffe4c552d45c5690c6d825e9310769bf",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
                 "shasum": ""
             },
             "require": {
@@ -6671,7 +6609,8 @@
                 "phpunit/phpunit": "<8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=9.6.11 <10.4"
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
             },
             "type": "library",
             "autoload": {
@@ -6728,20 +6667,20 @@
                 "security": "https://github.com/mockery/mockery/security/advisories",
                 "source": "https://github.com/mockery/mockery"
             },
-            "time": "2023-10-01T17:31:30+00:00"
+            "time": "2024-05-16T03:13:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.x-dev",
+            "version": "1.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "5ee4e978b7fec6dbd844282126a5a32daa2044c6"
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/5ee4e978b7fec6dbd844282126a5a32daa2044c6",
-                "reference": "5ee4e978b7fec6dbd844282126a5a32daa2044c6",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
                 "shasum": ""
             },
             "require": {
@@ -6757,7 +6696,6 @@
                 "phpspec/prophecy": "^1.10",
                 "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "files": [
@@ -6781,7 +6719,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.x"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
             },
             "funding": [
                 {
@@ -6789,20 +6727,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-30T16:10:21+00:00"
+            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "dev-master",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "50f0d9c9d0e3cff1163c959c50aaaaa4a7115f08"
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/50f0d9c9d0e3cff1163c959c50aaaaa4a7115f08",
-                "reference": "50f0d9c9d0e3cff1163c959c50aaaaa4a7115f08",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
                 "shasum": ""
             },
             "require": {
@@ -6815,7 +6753,6 @@
                 "ircmaxell/php-yacc": "^0.0.7",
                 "phpunit/phpunit": "^9.0"
             },
-            "default-branch": true,
             "bin": [
                 "bin/php-parse"
             ],
@@ -6846,29 +6783,29 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/master"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
-            "time": "2026-02-26T13:20:22+00:00"
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v8.x-dev",
+            "version": "v8.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "a1ed3fa530fd60bc515f9303e8520fcb7d4bd935"
+                "reference": "716af8f95a470e9094cfca09ed897b023be191a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/a1ed3fa530fd60bc515f9303e8520fcb7d4bd935",
-                "reference": "a1ed3fa530fd60bc515f9303e8520fcb7d4bd935",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/716af8f95a470e9094cfca09ed897b023be191a5",
+                "reference": "716af8f95a470e9094cfca09ed897b023be191a5",
                 "shasum": ""
             },
             "require": {
                 "filp/whoops": "^2.18.4",
                 "nunomaduro/termwind": "^2.4.0",
                 "php": "^8.2.0",
-                "symfony/console": "^7.4.4 || ^8.0.4"
+                "symfony/console": "^7.4.8 || ^8.0.8"
             },
             "conflict": {
                 "laravel/framework": "<11.48.0 || >=14.0.0",
@@ -6876,14 +6813,13 @@
             },
             "require-dev": {
                 "brianium/paratest": "^7.8.5",
-                "larastan/larastan": "^3.9.2",
-                "laravel/framework": "^11.48.0 || ^12.52.0",
-                "laravel/pint": "^1.27.1",
-                "orchestra/testbench-core": "^9.12.0 || ^10.9.0",
-                "pestphp/pest": "^3.8.5 || ^4.4.1 || ^5.0.0",
-                "sebastian/environment": "^7.2.1 || ^8.0.3 || ^9.0.0"
+                "larastan/larastan": "^3.9.6",
+                "laravel/framework": "^11.48.0 || ^12.56.0 || ^13.5.0",
+                "laravel/pint": "^1.29.1",
+                "orchestra/testbench-core": "^9.12.0 || ^10.12.1 || ^11.2.1",
+                "pestphp/pest": "^3.8.5 || ^4.4.3 || ^5.0.0",
+                "sebastian/environment": "^7.2.1 || ^8.0.4 || ^9.3.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -6945,48 +6881,42 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2026-02-17T17:33:08+00:00"
+            "time": "2026-04-21T14:04:20+00:00"
         },
         {
             "name": "orchestra/canvas",
-            "version": "10.x-dev",
+            "version": "v11.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/canvas.git",
-                "reference": "a58584838b8202abd96e03f74408141c73eab040"
+                "reference": "d240410f4cd89b380d7d89b5bbaf60c32f4fb691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/canvas/zipball/a58584838b8202abd96e03f74408141c73eab040",
-                "reference": "a58584838b8202abd96e03f74408141c73eab040",
+                "url": "https://api.github.com/repos/orchestral/canvas/zipball/d240410f4cd89b380d7d89b5bbaf60c32f4fb691",
+                "reference": "d240410f4cd89b380d7d89b5bbaf60c32f4fb691",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
                 "composer/semver": "^3.0",
-                "illuminate/console": "^12.40.0",
-                "illuminate/database": "^12.40.0",
-                "illuminate/filesystem": "^12.40.0",
-                "illuminate/support": "^12.40.0",
-                "orchestra/canvas-core": "^10.1.2",
+                "illuminate/console": "^13.0.0",
+                "illuminate/database": "^13.0.0",
+                "illuminate/filesystem": "^13.0.0",
+                "illuminate/support": "^13.0.0",
+                "orchestra/canvas-core": "^11.0.0",
                 "orchestra/sidekick": "~1.1.23|~1.2.20",
-                "orchestra/testbench-core": "^10.8.0",
-                "php": "^8.2",
-                "symfony/polyfill-php83": "^1.33",
-                "symfony/yaml": "^7.2.0"
-            },
-            "conflict": {
-                "laravel/framework": "<12.40.0|>=13.0.0"
+                "orchestra/testbench-core": "^11.0.0",
+                "php": "^8.3",
+                "symfony/yaml": "^7.4.0|^8.0.0"
             },
             "require-dev": {
-                "laravel/framework": "^12.40.0",
+                "laravel/framework": "^13.0.0",
                 "laravel/pint": "^1.24",
-                "mockery/mockery": "^1.6.12",
+                "mockery/mockery": "^1.6.10",
                 "phpstan/phpstan": "^2.1.14",
-                "phpunit/phpunit": "^11.5.18|^12.0",
-                "spatie/laravel-ray": "^1.42.0"
+                "phpunit/phpunit": "^11.5.50|^12.5.8|^13.0.0"
             },
-            "default-branch": true,
             "bin": [
                 "canvas"
             ],
@@ -7020,44 +6950,41 @@
             "description": "Code Generators for Laravel Applications and Packages",
             "support": {
                 "issues": "https://github.com/orchestral/canvas/issues",
-                "source": "https://github.com/orchestral/canvas/tree/10.x"
+                "source": "https://github.com/orchestral/canvas/tree/v11.0.1"
             },
-            "time": "2026-02-23T14:53:28+00:00"
+            "time": "2026-03-18T22:46:12+00:00"
         },
         {
             "name": "orchestra/canvas-core",
-            "version": "10.x-dev",
+            "version": "v11.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/canvas-core.git",
-                "reference": "5a437210f54aef14db9fc52f3850c764c41e80ff"
+                "reference": "88d091ff989748e2ca447bca0cd06ab14671ba82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/canvas-core/zipball/5a437210f54aef14db9fc52f3850c764c41e80ff",
-                "reference": "5a437210f54aef14db9fc52f3850c764c41e80ff",
+                "url": "https://api.github.com/repos/orchestral/canvas-core/zipball/88d091ff989748e2ca447bca0cd06ab14671ba82",
+                "reference": "88d091ff989748e2ca447bca0cd06ab14671ba82",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
                 "composer/semver": "^3.0",
-                "illuminate/console": "^12.40.0",
-                "illuminate/support": "^12.40.0",
+                "illuminate/console": "^13.0",
+                "illuminate/support": "^13.0",
                 "orchestra/sidekick": "~1.1.23|~1.2.20",
-                "php": "^8.2",
-                "symfony/polyfill-php83": "^1.33"
+                "php": "^8.3"
             },
             "require-dev": {
-                "laravel/framework": "^12.40.0",
+                "laravel/framework": "^13.0",
                 "laravel/pint": "^1.24",
                 "mockery/mockery": "^1.6.10",
-                "orchestra/testbench-core": "^10.8.0",
+                "orchestra/testbench-core": "^11.0",
                 "phpstan/phpstan": "^2.1.17",
-                "phpunit/phpunit": "^11.5.12|^12.0.1",
-                "spatie/laravel-ray": "^1.40.2",
-                "symfony/yaml": "^7.2"
+                "phpunit/phpunit": "^11.5.50|^12.5.8|^13.0.0",
+                "symfony/yaml": "^7.4|^8.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -7088,22 +7015,22 @@
             "description": "Code Generators Builder for Laravel Applications and Packages",
             "support": {
                 "issues": "https://github.com/orchestral/canvas/issues",
-                "source": "https://github.com/orchestral/canvas-core/tree/10.x"
+                "source": "https://github.com/orchestral/canvas-core/tree/v11.0.0"
             },
-            "time": "2026-02-24T13:20:49+00:00"
+            "time": "2026-03-16T15:10:50+00:00"
         },
         {
             "name": "orchestra/sidekick",
-            "version": "1.2.x-dev",
+            "version": "v1.2.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/sidekick.git",
-                "reference": "ccbd3c7aff8fadcfa5e7f20ef9c4666c8bb15eb7"
+                "reference": "267a71b56cb2fe1a634d69fc99889c671b77ff43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/sidekick/zipball/ccbd3c7aff8fadcfa5e7f20ef9c4666c8bb15eb7",
-                "reference": "ccbd3c7aff8fadcfa5e7f20ef9c4666c8bb15eb7",
+                "url": "https://api.github.com/repos/orchestral/sidekick/zipball/267a71b56cb2fe1a634d69fc99889c671b77ff43",
+                "reference": "267a71b56cb2fe1a634d69fc99889c671b77ff43",
                 "shasum": ""
             },
             "require": {
@@ -7119,7 +7046,7 @@
                 "mockery/mockery": "^1.5.1",
                 "orchestra/testbench-core": "^8.37.0|^9.14.0|^10.2.0|^11.0",
                 "phpstan/phpstan": "^2.1.14",
-                "phpunit/phpunit": "^10.0|^11.0|^12.0|^13.0",
+                "phpunit/phpunit": "^10.0|^11.0|^12.0",
                 "symfony/process": "^6.0|^7.0"
             },
             "type": "library",
@@ -7147,38 +7074,37 @@
             "description": "Packages Toolkit Utilities and Helpers for Laravel",
             "support": {
                 "issues": "https://github.com/orchestral/sidekick/issues",
-                "source": "https://github.com/orchestral/sidekick/tree/1.2.x"
+                "source": "https://github.com/orchestral/sidekick/tree/v1.2.20"
             },
-            "time": "2026-02-20T16:08:18+00:00"
+            "time": "2026-01-12T11:09:33+00:00"
         },
         {
             "name": "orchestra/testbench",
-            "version": "10.x-dev",
+            "version": "v11.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench.git",
-                "reference": "040a37b60e1a9d7ae10b496407b6c3bb63b47038"
+                "reference": "997f33e5200c7e8db4756b35a9deb3f5f3086759"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench/zipball/040a37b60e1a9d7ae10b496407b6c3bb63b47038",
-                "reference": "040a37b60e1a9d7ae10b496407b6c3bb63b47038",
+                "url": "https://api.github.com/repos/orchestral/testbench/zipball/997f33e5200c7e8db4756b35a9deb3f5f3086759",
+                "reference": "997f33e5200c7e8db4756b35a9deb3f5f3086759",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
                 "fakerphp/faker": "^1.23",
-                "laravel/framework": "^12.40.0",
+                "laravel/framework": "^13.1.1",
                 "mockery/mockery": "^1.6.10",
-                "orchestra/testbench-core": "^10.9.0",
-                "orchestra/workbench": "^10.0.8",
-                "php": "^8.2",
-                "phpunit/phpunit": "^11.5.3|^12.0.1",
-                "symfony/process": "^7.2",
-                "symfony/yaml": "^7.2",
+                "orchestra/testbench-core": "^11.2.0",
+                "orchestra/workbench": "^11.0.1",
+                "php": "^8.3",
+                "phpunit/phpunit": "^11.5.50|^12.5.8|^13.0.0",
+                "symfony/process": "^7.4.5|^8.0.5",
+                "symfony/yaml": "^7.4|^8.0",
                 "vlucas/phpdotenv": "^5.6.1"
             },
-            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -7203,65 +7129,64 @@
             ],
             "support": {
                 "issues": "https://github.com/orchestral/testbench/issues",
-                "source": "https://github.com/orchestral/testbench/tree/10.x"
+                "source": "https://github.com/orchestral/testbench/tree/v11.1.0"
             },
-            "time": "2026-01-14T03:26:57+00:00"
+            "time": "2026-04-09T05:11:06+00:00"
         },
         {
             "name": "orchestra/testbench-core",
-            "version": "10.x-dev",
+            "version": "v11.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench-core.git",
-                "reference": "30c0b53d9d7d1d6000f78c59687fb1f67db543a8"
+                "reference": "527fe9941b8bdec2914d2a19048b0c40c6c5d87c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/30c0b53d9d7d1d6000f78c59687fb1f67db543a8",
-                "reference": "30c0b53d9d7d1d6000f78c59687fb1f67db543a8",
+                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/527fe9941b8bdec2914d2a19048b0c40c6c5d87c",
+                "reference": "527fe9941b8bdec2914d2a19048b0c40c6c5d87c",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
                 "orchestra/sidekick": "~1.1.23|~1.2.20",
-                "php": "^8.2",
+                "php": "^8.3",
                 "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-php83": "^1.33"
+                "symfony/polyfill-php84": "^1.34.0"
             },
             "conflict": {
                 "brianium/paratest": "<7.3.0|>=8.0.0",
-                "laravel/framework": "<12.40.0|>=13.0.0",
-                "laravel/serializable-closure": "<1.3.0|>=2.0.0 <2.0.3|>=3.0.0",
-                "nunomaduro/collision": "<8.0.0|>=9.0.0",
-                "phpunit/phpunit": "<10.5.35|>=11.0.0 <11.5.3|12.0.0|>=13.1.0"
+                "laravel/framework": "<13.10.0|>=14.0.0",
+                "laravel/serializable-closure": ">=2.0.0 <2.0.10|>=3.0.0",
+                "nunomaduro/collision": "<8.9.0|>=9.0.0",
+                "phpunit/phpunit": "<11.5.50|>=12.0.0 <12.5.8|>=13.2.0"
             },
             "require-dev": {
                 "fakerphp/faker": "^1.24",
-                "laravel/framework": "^12.40.0",
+                "laravel/framework": "^13.10.0",
                 "laravel/pint": "^1.24",
-                "laravel/serializable-closure": "^1.3|^2.0.4",
+                "laravel/serializable-closure": "^2.0.10",
                 "mockery/mockery": "^1.6.10",
                 "phpstan/phpstan": "^2.1.38",
-                "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1|^13.0.0",
-                "spatie/laravel-ray": "^1.42.0",
-                "symfony/process": "^7.2.0",
-                "symfony/yaml": "^7.2.0",
+                "phpunit/phpunit": "^11.5.50|^12.5.8|^13.0.0",
+                "spatie/laravel-ray": "^1.43.6",
+                "symfony/process": "^7.4.5|^8.0.5",
+                "symfony/yaml": "^7.4.0|^8.0.0",
                 "vlucas/phpdotenv": "^5.6.1"
             },
             "suggest": {
                 "brianium/paratest": "Allow using parallel testing (^7.3).",
                 "ext-pcntl": "Required to use all features of the console signal trapping.",
                 "fakerphp/faker": "Allow using Faker for testing (^1.23).",
-                "laravel/framework": "Required for testing (^12.40.0).",
+                "laravel/framework": "Required for testing (^13.9.0).",
                 "mockery/mockery": "Allow using Mockery for testing (^1.6).",
-                "nunomaduro/collision": "Allow using Laravel style tests output and parallel testing (^8.0).",
-                "orchestra/testbench-dusk": "Allow using Laravel Dusk for testing (^10.0).",
-                "phpunit/phpunit": "Allow using PHPUnit for testing (^10.5.35|^11.5.3|^12.0.1|^13.0.0).",
-                "symfony/process": "Required to use Orchestra\\Testbench\\remote function (^7.2).",
-                "symfony/yaml": "Required for Testbench CLI (^7.2).",
+                "nunomaduro/collision": "Allow using Laravel style tests output and parallel testing (^8.9).",
+                "orchestra/testbench-dusk": "Allow using Laravel Dusk for testing (^11.0).",
+                "phpunit/phpunit": "Allow using PHPUnit for testing (^11.5.50|^12.5.8|^13.0.0).",
+                "symfony/process": "Required to use Orchestra\\Testbench\\remote function (^7.4|^8.0).",
+                "symfony/yaml": "Required for Testbench CLI (^7.4|^8.0).",
                 "vlucas/phpdotenv": "Required for Testbench CLI (^5.6.1)."
             },
-            "default-branch": true,
             "bin": [
                 "testbench"
             ],
@@ -7299,48 +7224,46 @@
                 "issues": "https://github.com/orchestral/testbench/issues",
                 "source": "https://github.com/orchestral/testbench-core"
             },
-            "time": "2026-02-20T16:11:52+00:00"
+            "time": "2026-06-02T03:43:15+00:00"
         },
         {
             "name": "orchestra/workbench",
-            "version": "10.x-dev",
+            "version": "v11.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/workbench.git",
-                "reference": "6d8ecb3f636fc3aeba95a6bebb146f376b67fc1c"
+                "reference": "e750c7bcae4405e054ff286475502e23274de04b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/workbench/zipball/6d8ecb3f636fc3aeba95a6bebb146f376b67fc1c",
-                "reference": "6d8ecb3f636fc3aeba95a6bebb146f376b67fc1c",
+                "url": "https://api.github.com/repos/orchestral/workbench/zipball/e750c7bcae4405e054ff286475502e23274de04b",
+                "reference": "e750c7bcae4405e054ff286475502e23274de04b",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
                 "fakerphp/faker": "^1.23",
-                "laravel/framework": "^12.40.0",
-                "laravel/pail": "^1.2.2",
-                "laravel/tinker": "^2.10.1",
-                "nunomaduro/collision": "^8.6",
-                "orchestra/canvas": "^10.1.1",
+                "laravel/framework": "^13.0.0",
+                "laravel/pail": "^1.2.5",
+                "laravel/tinker": "^3.0.0",
+                "nunomaduro/collision": "^8.9",
+                "orchestra/canvas": "^11.0.1",
                 "orchestra/sidekick": "~1.1.23|~1.2.20",
-                "orchestra/testbench-core": "^10.8.0",
-                "php": "^8.2",
-                "symfony/polyfill-php83": "^1.33",
-                "symfony/process": "^7.2",
-                "symfony/yaml": "^7.2"
+                "orchestra/testbench-core": "^11.1.0",
+                "php": "^8.3",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0"
             },
             "require-dev": {
                 "laravel/pint": "^1.22.0",
                 "mockery/mockery": "^1.6.12",
                 "phpstan/phpstan": "^2.1.33",
-                "phpunit/phpunit": "^11.5.3|^12.0.1",
-                "spatie/laravel-ray": "^1.42.0"
+                "phpunit/phpunit": "^11.5.50|^12.5.8|^13.0.0",
+                "spatie/laravel-ray": "^1.43.6"
             },
             "suggest": {
                 "ext-pcntl": "Required to use all features of the console signal trapping."
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -7366,22 +7289,22 @@
             ],
             "support": {
                 "issues": "https://github.com/orchestral/workbench/issues",
-                "source": "https://github.com/orchestral/workbench/tree/10.x"
+                "source": "https://github.com/orchestral/workbench/tree/v11.1.0"
             },
-            "time": "2026-01-28T05:23:30+00:00"
+            "time": "2026-03-24T23:09:55+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "dev-master",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "c581d4941e196459bf76c945a8ca922963a66708"
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/c581d4941e196459bf76c945a8ca922963a66708",
-                "reference": "c581d4941e196459bf76c945a8ca922963a66708",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
                 "shasum": ""
             },
             "require": {
@@ -7392,7 +7315,6 @@
                 "phar-io/version": "^3.0.1",
                 "php": "^7.2 || ^8.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -7428,7 +7350,7 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/master"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
             },
             "funding": [
                 {
@@ -7436,7 +7358,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-27T15:23:09+00:00"
+            "time": "2024-03-03T12:33:53+00:00"
         },
         {
             "name": "phar-io/version",
@@ -7491,16 +7413,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "11.0.x-dev",
+            "version": "11.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "e9886462f454159e97d6e8e343cb1b512f6f0ff4"
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/e9886462f454159e97d6e8e343cb1b512f6f0ff4",
-                "reference": "e9886462f454159e97d6e8e343cb1b512f6f0ff4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
                 "shasum": ""
             },
             "require": {
@@ -7509,6 +7431,7 @@
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^5.7.0",
                 "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
                 "phpunit/php-text-template": "^4.0.1",
                 "sebastian/code-unit-reverse-lookup": "^4.0.1",
                 "sebastian/complexity": "^4.0.1",
@@ -7556,7 +7479,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
             },
             "funding": [
                 {
@@ -7576,11 +7499,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-10T06:06:34+00:00"
+            "time": "2025-12-24T07:01:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "5.1.x-dev",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
@@ -7653,16 +7576,16 @@
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "5.0.x-dev",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "cdf46882fb81433d671ed4ba64c62da7e62b1f12"
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/cdf46882fb81433d671ed4ba64c62da7e62b1f12",
-                "reference": "cdf46882fb81433d671ed4ba64c62da7e62b1f12",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
                 "shasum": ""
             },
             "require": {
@@ -7670,7 +7593,7 @@
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^11.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -7705,47 +7628,35 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
                 "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-invoker",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-09-26T11:56:54+00:00"
+            "time": "2024-07-03T05:07:44+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "4.0.x-dev",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "51c29005b7c2781f72381ff01a2fe79be7096d29"
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/51c29005b7c2781f72381ff01a2fe79be7096d29",
-                "reference": "51c29005b7c2781f72381ff01a2fe79be7096d29",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
@@ -7777,47 +7688,35 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
                 "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-text-template",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-09-26T12:02:43+00:00"
+            "time": "2024-07-03T05:08:43+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "7.0.x-dev",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "297d0ed22e93b061dfa9697636255c6b4570786a"
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/297d0ed22e93b061dfa9697636255c6b4570786a",
-                "reference": "297d0ed22e93b061dfa9697636255c6b4570786a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
@@ -7849,40 +7748,28 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
                 "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-timer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-11-25T07:59:26+00:00"
+            "time": "2024-07-03T05:09:35+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.x-dev",
+            "version": "11.5.55",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "4f3eede277e3fe48add933e3133f42cace068aee"
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4f3eede277e3fe48add933e3133f42cace068aee",
-                "reference": "4f3eede277e3fe48add933e3133f42cace068aee",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00",
                 "shasum": ""
             },
             "require": {
@@ -7955,7 +7842,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.55"
             },
             "funding": [
                 {
@@ -7979,20 +7866,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-23T16:14:50+00:00"
+            "time": "2026-02-18T12:37:06+00:00"
         },
         {
             "name": "psy/psysh",
-            "version": "dev-main",
+            "version": "v0.12.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "281ade25ad712eae3cd29204ecd6c3e31b13a007"
+                "reference": "4dcc0f08047d52bbde475eda481146fd8e27e1a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/281ade25ad712eae3cd29204ecd6c3e31b13a007",
-                "reference": "281ade25ad712eae3cd29204ecd6c3e31b13a007",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/4dcc0f08047d52bbde475eda481146fd8e27e1a4",
+                "reference": "4dcc0f08047d52bbde475eda481146fd8e27e1a4",
                 "shasum": ""
             },
             "require": {
@@ -8015,7 +7902,6 @@
                 "ext-pcntl": "Enabling the PCNTL extension makes PsySH a lot happier :)",
                 "ext-posix": "If you have PCNTL, you'll want the POSIX extension as well."
             },
-            "default-branch": true,
             "bin": [
                 "bin/psysh"
             ],
@@ -8057,29 +7943,29 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/main"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.23"
             },
-            "time": "2026-02-23T20:17:41+00:00"
+            "time": "2026-05-23T13:41:31+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "3.0.x-dev",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "249c25bbb38eb80f9ba1682ba5617759f2b853a8"
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/249c25bbb38eb80f9ba1682ba5617759f2b853a8",
-                "reference": "249c25bbb38eb80f9ba1682ba5617759f2b853a8",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
@@ -8108,40 +7994,28 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-12-31T13:25:36+00:00"
+            "time": "2024-07-03T04:41:36+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "dev-main",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "23caa57776ddcaa35a2965b93d5f4212a2c3a2d9"
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/23caa57776ddcaa35a2965b93d5f4212a2c3a2d9",
-                "reference": "23caa57776ddcaa35a2965b93d5f4212a2c3a2d9",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
                 "shasum": ""
             },
             "require": {
@@ -8150,7 +8024,6 @@
             "require-dev": {
                 "phpunit/phpunit": "^11.5"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -8178,49 +8051,36 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
                 "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/main"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/code-unit",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-05-25T06:37:26+00:00"
+            "time": "2025-03-19T07:56:08+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "dev-main",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "5cf245ed8605ac5c89946e4bcdcbbd1565b19d9f"
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5cf245ed8605ac5c89946e4bcdcbbd1565b19d9f",
-                "reference": "5cf245ed8605ac5c89946e4bcdcbbd1565b19d9f",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^11.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -8247,40 +8107,28 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
                 "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/main"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/code-unit-reverse-lookup",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-05-25T06:37:50+00:00"
+            "time": "2024-07-03T04:45:54+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "6.3.x-dev",
+            "version": "6.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "ee0326914d9fe5797f8f8270d4eb36c42c64afd5"
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ee0326914d9fe5797f8f8270d4eb36c42c64afd5",
-                "reference": "ee0326914d9fe5797f8f8270d4eb36c42c64afd5",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
                 "shasum": ""
             },
             "require": {
@@ -8339,7 +8187,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
             },
             "funding": [
                 {
@@ -8359,20 +8207,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:33:09+00:00"
+            "time": "2026-01-24T09:26:40+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "4.0.x-dev",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "66dc7be5b87498fc0a94565e3b869515becc6569"
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/66dc7be5b87498fc0a94565e3b869515becc6569",
-                "reference": "66dc7be5b87498fc0a94565e3b869515becc6569",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
                 "shasum": ""
             },
             "require": {
@@ -8380,7 +8228,7 @@
                 "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
@@ -8409,47 +8257,35 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
                 "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/complexity",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-09-26T09:28:11+00:00"
+            "time": "2024-07-03T04:49:50+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "6.0.x-dev",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "a42039c742783604f4156c17357f22e335ba5d1c"
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/a42039c742783604f4156c17357f22e335ba5d1c",
-                "reference": "a42039c742783604f4156c17357f22e335ba5d1c",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3",
+                "phpunit/phpunit": "^11.0",
                 "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
@@ -8488,40 +8324,28 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/6.0"
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/diff",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-09-26T09:40:22+00:00"
+            "time": "2024-07-03T04:53:05+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "7.2.x-dev",
+            "version": "7.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "05faa86b4c0042e122ed6be66766b9bf820775d6"
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/05faa86b4c0042e122ed6be66766b9bf820775d6",
-                "reference": "05faa86b4c0042e122ed6be66766b9bf820775d6",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
                 "shasum": ""
             },
             "require": {
@@ -8564,7 +8388,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/7.2"
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
             },
             "funding": [
                 {
@@ -8584,20 +8408,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-26T09:53:03+00:00"
+            "time": "2025-05-21T11:55:47+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "6.3.x-dev",
+            "version": "6.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "c939676885df069c0bc467ca4a1ac7dd367db7a8"
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/c939676885df069c0bc467ca4a1ac7dd367db7a8",
-                "reference": "c939676885df069c0bc467ca4a1ac7dd367db7a8",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
                 "shasum": ""
             },
             "require": {
@@ -8654,7 +8478,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
             },
             "funding": [
                 {
@@ -8674,20 +8498,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-26T11:23:57+00:00"
+            "time": "2025-09-24T06:12:51+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "7.0.x-dev",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "88b1eb038ff5daa6f3c2b76bea3cd0ac48626f53"
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/88b1eb038ff5daa6f3c2b76bea3cd0ac48626f53",
-                "reference": "88b1eb038ff5daa6f3c2b76bea3cd0ac48626f53",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
                 "shasum": ""
             },
             "require": {
@@ -8697,7 +8521,7 @@
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
@@ -8728,40 +8552,28 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-09-26T11:31:14+00:00"
+            "time": "2024-07-03T04:57:36+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "3.0.x-dev",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "8426f4eebca3f4003616c617b89094be52fc7b16"
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/8426f4eebca3f4003616c617b89094be52fc7b16",
-                "reference": "8426f4eebca3f4003616c617b89094be52fc7b16",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
                 "shasum": ""
             },
             "require": {
@@ -8769,7 +8581,7 @@
                 "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
@@ -8798,40 +8610,28 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/lines-of-code",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-09-26T11:36:26+00:00"
+            "time": "2024-07-03T04:58:38+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "6.0.x-dev",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "1748f199f50f7deb6f12c4f08cddc306cf6fd2e2"
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1748f199f50f7deb6f12c4f08cddc306cf6fd2e2",
-                "reference": "1748f199f50f7deb6f12c4f08cddc306cf6fd2e2",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
                 "shasum": ""
             },
             "require": {
@@ -8840,7 +8640,7 @@
                 "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
@@ -8868,47 +8668,35 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
                 "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/object-enumerator",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-09-26T11:41:57+00:00"
+            "time": "2024-07-03T05:00:13+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "4.0.x-dev",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "89dc41f115e98bfa597501c28e489dd7db93b855"
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/89dc41f115e98bfa597501c28e489dd7db93b855",
-                "reference": "89dc41f115e98bfa597501c28e489dd7db93b855",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
@@ -8936,40 +8724,28 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
                 "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/object-reflector",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-09-26T11:47:29+00:00"
+            "time": "2024-07-03T05:01:32+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "6.0.x-dev",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "5d8d13f2fcb3c9839d4ff05613e008ceb02bfc64"
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5d8d13f2fcb3c9839d4ff05613e008ceb02bfc64",
-                "reference": "5d8d13f2fcb3c9839d4ff05613e008ceb02bfc64",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
                 "shasum": ""
             },
             "require": {
@@ -9012,7 +8788,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
                 "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
             },
             "funding": [
                 {
@@ -9032,20 +8808,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-26T12:14:53+00:00"
+            "time": "2025-08-13T04:42:22+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "5.1.x-dev",
+            "version": "5.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "6abfe424c60c52cafb35c5c78e142304925817be"
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/6abfe424c60c52cafb35c5c78e142304925817be",
-                "reference": "6abfe424c60c52cafb35c5c78e142304925817be",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
                 "shasum": ""
             },
             "require": {
@@ -9081,7 +8857,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
                 "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/5.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
             },
             "funding": [
                 {
@@ -9101,20 +8877,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-26T12:19:36+00:00"
+            "time": "2025-08-09T06:55:48+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "5.0.x-dev",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "0e6075acec40b5ed867eefd095488171404c63fa"
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/0e6075acec40b5ed867eefd095488171404c63fa",
-                "reference": "0e6075acec40b5ed867eefd095488171404c63fa",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
                 "shasum": ""
             },
             "require": {
@@ -9147,27 +8923,15 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
                 "security": "https://github.com/sebastianbergmann/version/security/policy",
-                "source": "https://github.com/sebastianbergmann/version/tree/5.0"
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/version",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-09-26T12:27:57+00:00"
+            "time": "2024-10-09T05:16:32+00:00"
         },
         {
             "name": "staabm/side-effects-detector",
@@ -9222,29 +8986,109 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "7.4.x-dev",
+            "name": "symfony/polyfill-php83",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "58751048de17bae71c5aa0d13cb19d79bca26391"
+                "url": "https://github.com/symfony/polyfill-php83.git",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/58751048de17bae71c5aa0d13cb19d79bca26391",
-                "reference": "58751048de17bae71c5aa0d13cb19d79bca26391",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php83\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-27T06:51:48+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "efb42bd2c6f4f3ccfd4683583449938b5fc146b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/efb42bd2c6f4f3ccfd4683583449938b5fc146b0",
+                "reference": "efb42bd2c6f4f3ccfd4683583449938b5fc146b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/console": "<6.4"
+                "symfony/console": "<7.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0"
+                "symfony/console": "^7.4|^8.0",
+                "yaml/yaml-test-suite": "*"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -9275,7 +9119,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/7.4"
+                "source": "https://github.com/symfony/yaml/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -9295,7 +9139,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-09T09:33:46+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -9349,9 +9193,9 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "stability-flags": {},
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.1"

--- a/composer.lock
+++ b/composer.lock
@@ -773,22 +773,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.12.0",
+            "version": "7.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "eaa81598031cf57a9e36258c8546defffc994cba"
+                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/eaa81598031cf57a9e36258c8546defffc994cba",
-                "reference": "eaa81598031cf57a9e36258c8546defffc994cba",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d34627490fbc03bf5c5d7cfed81f2faa19519425",
+                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^2.5",
-                "guzzlehttp/psr7": "^2.12",
+                "guzzlehttp/psr7": "^2.12.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
@@ -801,7 +801,7 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.5",
+                "guzzlehttp/test-server": "^0.5.1",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -881,7 +881,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.12.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.12.1"
             },
             "funding": [
                 {
@@ -897,7 +897,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-16T22:11:48+00:00"
+            "time": "2026-06-18T14:12:49+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -985,16 +985,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.0",
+            "version": "2.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "9b38012e7b54f594707e6db52c684dc0a74b3a43"
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9b38012e7b54f594707e6db52c684dc0a74b3a43",
-                "reference": "9b38012e7b54f594707e6db52c684dc0a74b3a43",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
                 "shasum": ""
             },
             "require": {
@@ -1084,7 +1084,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.1"
             },
             "funding": [
                 {
@@ -1100,7 +1100,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-16T21:50:11+00:00"
+            "time": "2026-06-18T09:49:37+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",

--- a/src/Actions/ShortUrlRedirect.php
+++ b/src/Actions/ShortUrlRedirect.php
@@ -46,12 +46,8 @@ class ShortUrlRedirect extends Controller
          * Get Short URL Identifier & Validate (with domain)
          */
         try {
-            $this->shortUrl = UrlService::findByIdentifier($this->identifier, $this->domain);
+            $this->shortUrl = UrlService::findForRedirectByIdentifier($this->identifier, $this->domain);
         } catch (UrlRepositoryException $e) {
-            abort(404);
-        }
-
-        if (! $this->shortUrl) {
             abort(404);
         }
 
@@ -80,8 +76,8 @@ class ShortUrlRedirect extends Controller
              * ShortUrl is Password Protected ---
              * Record the click and render the protected view.
              */
-            ClickService::track(
-                $this->identifier,
+            ClickService::trackShortUrl(
+                $this->shortUrl,
                 $this->request->ip(),
                 ClickService::$SUCCESS_PROTECTED,
                 false,
@@ -98,8 +94,8 @@ class ShortUrlRedirect extends Controller
          * ShortUrl Successfully Routed ---
          * Record the click and route away.
          */
-        ClickService::track(
-            $this->identifier,
+        ClickService::trackShortUrl(
+            $this->shortUrl,
             $this->request->ip(),
             ClickService::$SUCCESS_ROUTED,
             false,
@@ -128,8 +124,8 @@ class ShortUrlRedirect extends Controller
              * ShortUrl is not active yet ---
              * Record the click and abort.
              */
-            ClickService::track(
-                $this->identifier,
+            ClickService::trackShortUrl(
+                $this->shortUrl,
                 $this->request->ip(),
                 ClickService::$FAILURE_ACTIVATION,
                 false,
@@ -152,8 +148,8 @@ class ShortUrlRedirect extends Controller
              * ShortUrl Expired ---
              * Record the click and abort.
              */
-            ClickService::track(
-                $this->identifier,
+            ClickService::trackShortUrl(
+                $this->shortUrl,
                 $this->request->ip(),
                 ClickService::$FAILURE_EXPIRATION,
                 false,
@@ -161,7 +157,11 @@ class ShortUrlRedirect extends Controller
             );
 
             try {
-                ShortUrlExpired::dispatch($this->shortUrl, $this->identifier, $this->domain);
+                ShortUrlExpired::dispatch(
+                    UrlService::findByIdentifier($this->identifier, $this->domain),
+                    $this->identifier,
+                    $this->domain
+                );
             } catch (\Throwable $e) {
                 report($e);
             }
@@ -185,8 +185,8 @@ class ShortUrlRedirect extends Controller
              * ShortUrl Limit Reached ---
              * Record the click and abort.
              */
-            ClickService::track(
-                $this->identifier,
+            ClickService::trackShortUrl(
+                $this->shortUrl,
                 $this->request->ip(),
                 ClickService::$FAILURE_LIMIT,
                 false,

--- a/src/Builders/ClickQueryBuilder/ClickQueryBuilder.php
+++ b/src/Builders/ClickQueryBuilder/ClickQueryBuilder.php
@@ -74,10 +74,17 @@ class ClickQueryBuilder extends Builder
 
     public function isNotExpired(): ClickQueryBuilder
     {
-        return $this->expirationFilter('>', now()->timestamp);
+        $now = now()->timestamp;
+
+        return $this->whereIn('short_url_id', function ($query) use ($now) {
+            $query->from('short_urls');
+            $query->whereNull('expiration')
+                ->orWhere('expiration', '>', $now);
+            $query->select('id');
+        });
     }
 
-    protected function expirationFilter(string $direction, $current_timestamp): ClickQueryBuilder
+    protected function expirationFilter(string $direction, int $current_timestamp): ClickQueryBuilder
     {
         return $this->whereIn('short_url_id', function ($query) use ($direction, $current_timestamp) {
             $query->from('short_urls');
@@ -88,16 +95,21 @@ class ClickQueryBuilder extends Builder
 
     public function isExpiring(): ClickQueryBuilder
     {
-        return $this->whereIn('short_url_id', function ($query) {
+        $now = now();
+        $startsAt = $now->copy()->addMinute()->timestamp;
+        $endsAt = $now->copy()->addMinutes(30)->timestamp;
+
+        return $this->whereIn('short_url_id', function ($query) use ($startsAt, $endsAt) {
             $query->from('short_urls');
-            $query->whereBetween('expiration', [now()->addMinute()->timestamp, now()->addMinutes(30)]);
+            $query->whereBetween('expiration', [$startsAt, $endsAt]);
             $query->select('id');
         });
     }
 
     public function isExpired(): ClickQueryBuilder
     {
-        return $this->expirationFilter('<', now()->timestamp);
+        // Expired when now >= expiration, consistent with the redirect flow.
+        return $this->expirationFilter('<=', now()->timestamp);
     }
 
     public function whereOwnership(Model $model): ClickQueryBuilder

--- a/src/Builders/UrlBuilder/UrlBuilder.php
+++ b/src/Builders/UrlBuilder/UrlBuilder.php
@@ -154,10 +154,17 @@ class UrlBuilder implements UrlBuilderInterface
 
     /**
      * @return $this
+     *
+     * @throws UrlBuilderException
      */
     public function withOpenLimit(int $limit): UrlBuilder
     {
-        $this->shortUrlCollection->put('limit', $limit);
+        if ($limit < 0) {
+            throw new UrlBuilderException('Open limit cannot be negative.');
+        }
+
+        // A limit of 0 means unlimited opens.
+        $this->shortUrlCollection->put('limit', $limit === 0 ? null : $limit);
 
         $this->options->add(
             new WithOpenLimit
@@ -325,12 +332,14 @@ class UrlBuilder implements UrlBuilderInterface
         // Use domain-aware URL building if multi-domain is enabled
         $domain = $shortUrlCollection->get('domain');
         $identifier = $shortUrlCollection->get('identifier');
+        $prefix = $shortUrlCollection->get('custom_prefix');
+        $this->validateCustomPrefix($prefix, $domain);
 
         if (config('urlshortener.domains.enabled', false)) {
             $resolver = app(DomainResolver::class);
-            $url = $resolver->buildUrl($identifier, $domain);
+            $url = $resolver->buildUrlWithPrefix($identifier, $domain, $prefix);
         } else {
-            $url = $this->builtShortUrl($identifier);
+            $url = $this->builtShortUrl($identifier, $prefix);
         }
 
         try {
@@ -341,6 +350,30 @@ class UrlBuilder implements UrlBuilderInterface
         }
 
         return $url;
+    }
+
+    /**
+     * @throws UrlBuilderException
+     */
+    protected function validateCustomPrefix(?string $prefix, ?string $domain = null): void
+    {
+        if ($prefix === null) {
+            return;
+        }
+
+        $prefix = trim($prefix, '/');
+
+        if ($prefix === '') {
+            throw new UrlBuilderException('Custom prefix cannot be empty.');
+        }
+
+        $resolver = app(DomainResolver::class);
+
+        if (! in_array($prefix, $resolver->getRoutablePrefixes($domain), true)) {
+            throw new UrlBuilderException(
+                "Custom prefix '{$prefix}' is not registered. Add it to urlshortener.routing.additional_prefixes before using withPrefix()."
+            );
+        }
     }
 
     public function getOptions(): Collection

--- a/src/Models/ShortUrl.php
+++ b/src/Models/ShortUrl.php
@@ -71,7 +71,8 @@ class ShortUrl extends Model
 
     public function hasLimit(): bool
     {
-        return ! is_null($this->limit);
+        // A null or 0 limit both mean "unlimited opens".
+        return ! is_null($this->limit) && $this->limit > 0;
     }
 
     public function clicks(): HasMany

--- a/src/Repositories/UrlRepository.php
+++ b/src/Repositories/UrlRepository.php
@@ -185,6 +185,32 @@ class UrlRepository
     }
 
     /**
+     * Find a ShortUrl for redirect flow with minimal selected columns and no eager relations.
+     *
+     * @throws UrlRepositoryException
+     */
+    public static function findForRedirectByIdentifier(string $identifier, ?string $domain = null): ShortUrl
+    {
+        try {
+            $query = ShortUrl::query()
+                ->select(['id', 'domain', 'plain_text', 'identifier', 'activation', 'expiration', 'password', 'limit'])
+                ->where('identifier', $identifier);
+
+            if (config('urlshortener.domains.enabled', false)) {
+                if ($domain === null) {
+                    $query->whereNull('domain');
+                } else {
+                    $query->where('domain', $domain);
+                }
+            }
+
+            return $query->firstOrFail();
+        } catch (Exception $exception) {
+            throw new UrlRepositoryException('Unable to find short url identifier: '.$identifier, 0, $exception);
+        }
+    }
+
+    /**
      * Find all short URLs for a specific domain.
      */
     public static function findByDomain(string $domain): Collection

--- a/src/Services/ClickService.php
+++ b/src/Services/ClickService.php
@@ -9,6 +9,7 @@ use YorCreative\UrlShortener\Builders\ClickQueryBuilder\ClickQueryBuilder;
 use YorCreative\UrlShortener\Events\ShortUrlClicked;
 use YorCreative\UrlShortener\Exceptions\ClickServiceException;
 use YorCreative\UrlShortener\Exceptions\FilterClicksStrategyException;
+use YorCreative\UrlShortener\Models\ShortUrl;
 use YorCreative\UrlShortener\Models\ShortUrlClick;
 use YorCreative\UrlShortener\Repositories\ClickRepository;
 use YorCreative\UrlShortener\Repositories\LocationRepository;
@@ -49,19 +50,48 @@ class ClickService
     public static function track(string $identifier, string $request_ip, int $outcome_id, bool $test = false, ?string $domain = null): void
     {
         try {
-            ClickRepository::createClick(
-                UrlRepository::findByIdentifier($identifier, $domain)->id,
-                LocationRepository::findOrCreateLocationRecord(
-                    ! $test
-                        ? LocationRepository::getLocationFrom($request_ip)
-                        : LocationRepository::locationUnknown($request_ip)
-                )->id,
-                $outcome_id
-            );
+            $shortUrl = UrlRepository::findByIdentifier($identifier, $domain);
+            self::createClickForShortUrl($shortUrl, $request_ip, $outcome_id, $test);
         } catch (Exception $exception) {
             throw new ClickServiceException($exception->getMessage(), 0, $exception);
         }
 
+        self::dispatchShortUrlClicked($identifier, $outcome_id, $request_ip, $domain);
+    }
+
+    /**
+     * Track a click for an already-loaded ShortUrl.
+     *
+     * This avoids reloading the URL during redirect handling.
+     *
+     * @throws ClickServiceException
+     */
+    public static function trackShortUrl(ShortUrl $shortUrl, string $request_ip, int $outcome_id, bool $test = false, ?string $domain = null): void
+    {
+        try {
+            self::createClickForShortUrl($shortUrl, $request_ip, $outcome_id, $test);
+        } catch (Exception $exception) {
+            throw new ClickServiceException($exception->getMessage(), 0, $exception);
+        }
+
+        self::dispatchShortUrlClicked($shortUrl->identifier, $outcome_id, $request_ip, $domain ?? $shortUrl->domain);
+    }
+
+    protected static function createClickForShortUrl(ShortUrl $shortUrl, string $request_ip, int $outcome_id, bool $test): void
+    {
+        ClickRepository::createClick(
+            $shortUrl->id,
+            LocationRepository::findOrCreateLocationRecord(
+                ! $test
+                    ? LocationRepository::getLocationFrom($request_ip)
+                    : LocationRepository::locationUnknown($request_ip)
+            )->id,
+            $outcome_id
+        );
+    }
+
+    protected static function dispatchShortUrlClicked(string $identifier, int $outcome_id, string $request_ip, ?string $domain = null): void
+    {
         try {
             ShortUrlClicked::dispatch($identifier, $outcome_id, $request_ip, $domain);
         } catch (Throwable $e) {

--- a/src/Services/ClickService.php
+++ b/src/Services/ClickService.php
@@ -64,7 +64,7 @@ class ClickService
 
         try {
             ShortUrlClicked::dispatch($identifier, $outcome_id, $request_ip, $domain);
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             report($e);
         }
     }

--- a/src/Services/DomainResolver.php
+++ b/src/Services/DomainResolver.php
@@ -194,6 +194,45 @@ class DomainResolver implements DomainResolverInterface
     }
 
     /**
+     * Get prefixes that the package should register as routes.
+     *
+     * @return list<string>
+     */
+    public function getRoutablePrefixes(?string $domain = null): array
+    {
+        $prefixes = [];
+        $addPrefix = function ($prefix) use (&$prefixes): void {
+            if (! is_string($prefix)) {
+                return;
+            }
+
+            $prefix = trim($prefix, '/');
+
+            if ($prefix === '') {
+                return;
+            }
+
+            $prefixes[] = $prefix;
+        };
+
+        $addPrefix(config('urlshortener.branding.prefix') ?? 'v1');
+
+        if ($domain !== null) {
+            $addPrefix($this->getPrefix($domain));
+        } elseif (config('urlshortener.domains.enabled', false)) {
+            foreach (config('urlshortener.domains.hosts', []) as $config) {
+                $addPrefix($config['prefix'] ?? null);
+            }
+        }
+
+        foreach (config('urlshortener.routing.additional_prefixes', []) as $prefix) {
+            $addPrefix($prefix);
+        }
+
+        return array_values(array_unique($prefixes));
+    }
+
+    /**
      * Get the identifier length for a domain.
      */
     public function getIdentifierLength(?string $domain = null): int
@@ -209,6 +248,19 @@ class DomainResolver implements DomainResolverInterface
      * @throws DomainResolutionException
      */
     public function buildUrl(string $identifier, ?string $domain = null): string
+    {
+        return $this->buildUrlWithPrefix($identifier, $domain);
+    }
+
+    /**
+     * Build the full URL with a per-call prefix override.
+     *
+     * This is intentionally not part of DomainResolverInterface to avoid
+     * breaking existing custom resolver implementations in minor releases.
+     *
+     * @throws DomainResolutionException
+     */
+    public function buildUrlWithPrefix(string $identifier, ?string $domain = null, ?string $prefixOverride = null): string
     {
         $domain = $domain ?? $this->resolvedDomain ?? config('urlshortener.domains.default');
         $config = $this->getConfig($domain);
@@ -230,15 +282,19 @@ class DomainResolver implements DomainResolverInterface
 
         $host = str_ends_with($host, '/') ? $host : $host.'/';
 
-        $prefix = $config['prefix'] ?? null;
+        $prefix = $prefixOverride ?? ($config['prefix'] ?? null);
 
-        if ($prefix) {
-            $prefix = trim($prefix, '/').'/';
-
-            return $host.$prefix.$identifier;
+        if ($prefix === null) {
+            return $host.$identifier;
         }
 
-        return $host.$identifier;
+        $prefix = trim($prefix, '/');
+
+        if ($prefix === '') {
+            return $host.$identifier;
+        }
+
+        return $host.$prefix.'/'.$identifier;
     }
 
     /**

--- a/src/Services/UrlService.php
+++ b/src/Services/UrlService.php
@@ -42,6 +42,16 @@ class UrlService
     }
 
     /**
+     * Fetch minimal short URL data for redirect flow.
+     *
+     * @throws UrlRepositoryException
+     */
+    public static function findForRedirectByIdentifier(string $identifier, ?string $domain = null): ShortUrl
+    {
+        return UrlRepository::findForRedirectByIdentifier($identifier, $domain);
+    }
+
+    /**
      * @throws UrlRepositoryException
      */
     public static function findByUtmCombination(array $utm_combination, ?string $domain = null): Collection

--- a/src/Services/UrlService.php
+++ b/src/Services/UrlService.php
@@ -214,7 +214,7 @@ class UrlService
     /**
      * Find all short URLs for a specific domain.
      */
-    public static function findByDomain(string $domain): \Illuminate\Database\Eloquent\Collection
+    public static function findByDomain(string $domain): Collection
     {
         return UrlRepository::findByDomain($domain);
     }

--- a/src/Services/UrlValidator.php
+++ b/src/Services/UrlValidator.php
@@ -87,6 +87,7 @@ class UrlValidator
         // Check private IPs
         if (config('urlshortener.url_validation.block_private_ips', true)) {
             self::validateNotPrivateIp($host);
+            self::validateResolvedIps($host);
         }
     }
 
@@ -147,5 +148,84 @@ class UrlValidator
         }
 
         return false;
+    }
+
+    /**
+     * Resolve host and validate resolved IPs against private/reserved ranges.
+     *
+     * This closes a common bypass where a public hostname resolves to a private IP.
+     *
+     * @throws UrlBuilderException
+     */
+    protected static function validateResolvedIps(string $host): void
+    {
+        if (! config('urlshortener.url_validation.resolve_dns_private_ips', false)) {
+            return;
+        }
+
+        // Literal IPs are already validated by validateNotPrivateIp(); resolving
+        // them would be wasted DNS work.
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            return;
+        }
+
+        foreach (static::resolveHostIps($host) as $ip) {
+            if (static::isPrivateIp($ip)) {
+                throw new UrlBuilderException(
+                    "Host '{$host}' resolves to a private/internal IP address, which is not allowed."
+                );
+            }
+
+            if (config('urlshortener.url_validation.block_metadata_endpoints', true)
+                && in_array($ip, self::METADATA_ENDPOINTS, true)
+            ) {
+                throw new UrlBuilderException('Cloud metadata endpoints are blocked for security reasons.');
+            }
+        }
+    }
+
+    /**
+     * Resolve host to a list of IPv4/IPv6 addresses.
+     *
+     * @return list<string>
+     */
+    protected static function resolveHostIps(string $host): array
+    {
+        $ips = [];
+
+        if (function_exists('dns_get_record')) {
+            $aRecords = @dns_get_record($host, DNS_A);
+            if (is_array($aRecords)) {
+                foreach ($aRecords as $record) {
+                    if (isset($record['ip']) && filter_var($record['ip'], FILTER_VALIDATE_IP)) {
+                        $ips[] = $record['ip'];
+                    }
+                }
+            }
+
+            if (defined('DNS_AAAA')) {
+                $aaaaRecords = @dns_get_record($host, DNS_AAAA);
+                if (is_array($aaaaRecords)) {
+                    foreach ($aaaaRecords as $record) {
+                        if (isset($record['ipv6']) && filter_var($record['ipv6'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+                            $ips[] = $record['ipv6'];
+                        }
+                    }
+                }
+            }
+        }
+
+        if (empty($ips)) {
+            $fallback = @gethostbynamel($host);
+            if (is_array($fallback)) {
+                foreach ($fallback as $ip) {
+                    if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+                        $ips[] = $ip;
+                    }
+                }
+            }
+        }
+
+        return array_values(array_unique($ips));
     }
 }

--- a/src/Strategies/FilterClicks/Filters/StatusFilter.php
+++ b/src/Strategies/FilterClicks/Filters/StatusFilter.php
@@ -69,14 +69,22 @@ class StatusFilter extends AbstractFilter
 
         match ($status) {
             'active' => $query->whereIn('short_url_id', function ($q) use ($now) {
-                $q->from('short_urls')->where('expiration', '>', $now)->select('id');
+                $q->from('short_urls')
+                    ->whereNull('expiration')
+                    ->orWhere('expiration', '>', $now)
+                    ->select('id');
             }),
             'expired' => $query->whereIn('short_url_id', function ($q) use ($now) {
-                $q->from('short_urls')->where('expiration', '<', $now)->select('id');
+                // Expired when now >= expiration, consistent with the redirect flow.
+                $q->from('short_urls')->where('expiration', '<=', $now)->select('id');
             }),
             'expiring' => $query->whereIn('short_url_id', function ($q) {
+                $now = now();
+                $startsAt = $now->copy()->addMinute()->timestamp;
+                $endsAt = $now->copy()->addMinutes(30)->timestamp;
+
                 $q->from('short_urls')
-                    ->whereBetween('expiration', [now()->addMinute()->timestamp, now()->addMinutes(30)])
+                    ->whereBetween('expiration', [$startsAt, $endsAt])
                     ->select('id');
             }),
             default => null,

--- a/src/Traits/ShortUrlHelper.php
+++ b/src/Traits/ShortUrlHelper.php
@@ -29,9 +29,12 @@ trait ShortUrlHelper
                 'array',
             ],
             'outcome.*' => [
-                'in:1,2,3,4,5',
+                'in:1,2,3,4,5,6',
             ],
             'status' => [
+                'array',
+            ],
+            'status.*' => [
                 'in:active,expired,expiring',
             ],
             'identifiers' => [
@@ -78,6 +81,7 @@ trait ShortUrlHelper
             ],
         ], [
             'outcome.*.in' => 'Invalid outcome id provided.',
+            'status.*.in' => 'Invalid status provided.',
         ]);
 
         throw_if(
@@ -109,35 +113,35 @@ trait ShortUrlHelper
         return $identifier;
     }
 
-    private function builtShortUrl(string $identifier): string
+    private function builtShortUrl(string $identifier, ?string $prefixOverride = null): string
     {
         return str_replace(
             '{identifier}',
             $identifier,
-            $this->buildShortUrl()
+            $this->buildShortUrl($prefixOverride)
         );
     }
 
-    private function buildShortUrl(): string
+    private function buildShortUrl(?string $prefixOverride = null): string
     {
         $host = config('urlshortener.branding.host') ?? 'localhost.test';
         $host = str_ends_with($host, '/')
             ? $host
             : $host.'/';
 
-        $prefix = is_null(config('urlshortener.branding.prefix')) ? 'v1' : config('urlshortener.branding.prefix');
-        $prefix = str_starts_with($prefix, '/')
-            ? str_replace('/', '', $prefix)
-            : $prefix;
-
-        $prefix = str_ends_with($prefix, '/')
-            ? $prefix
-            : $prefix.'/';
-
+        $prefix = $prefixOverride ?? (is_null(config('urlshortener.branding.prefix')) ? 'v1' : config('urlshortener.branding.prefix'));
         $identifier = '{identifier}';
 
-        return is_null($prefix)
-            ? $host.$identifier
-            : $host.$prefix.$identifier;
+        if ($prefix === '') {
+            return $host.$identifier;
+        }
+
+        $prefix = trim($prefix, '/');
+
+        if ($prefix === '') {
+            return $host.$identifier;
+        }
+
+        return $host.$prefix.'/'.$identifier;
     }
 }

--- a/src/UrlShortenerServiceProvider.php
+++ b/src/UrlShortenerServiceProvider.php
@@ -44,6 +44,15 @@ class UrlShortenerServiceProvider extends ServiceProvider
             __DIR__.'/Utility/Views' => base_path('resources/views/yorcreative/urlshortener'),
             __DIR__.'/Utility/Config' => base_path('config'),
         ]);
+        $this->publishes([
+            __DIR__.'/Utility/Config/urlshortener.php' => config_path('urlshortener.php'),
+        ], 'urlshortener-config');
+        $this->publishes([
+            __DIR__.'/Utility/Views' => resource_path('views/yorcreative/urlshortener'),
+        ], 'urlshortener-views');
+        $this->publishes([
+            __DIR__.'/Utility/Migrations' => database_path('migrations'),
+        ], 'urlshortener-migrations');
 
         // Register middleware alias for users who want to apply it manually
         $router = $this->app->make('router');

--- a/src/Utility/Backpack/location.php
+++ b/src/Utility/Backpack/location.php
@@ -1,5 +1,11 @@
 <?php
 
+use Stevebauman\Location\Drivers\GeoPlugin;
+use Stevebauman\Location\Drivers\IpApi;
+use Stevebauman\Location\Drivers\IpInfo;
+use Stevebauman\Location\Drivers\MaxMind;
+use Stevebauman\Location\Position;
+
 return [
 
     /*
@@ -11,7 +17,7 @@ return [
     |
     */
 
-    'driver' => Stevebauman\Location\Drivers\IpApi::class,
+    'driver' => IpApi::class,
 
     /*
     |--------------------------------------------------------------------------
@@ -27,11 +33,11 @@ return [
 
     'fallbacks' => [
 
-        Stevebauman\Location\Drivers\IpInfo::class,
+        IpInfo::class,
 
-        Stevebauman\Location\Drivers\GeoPlugin::class,
+        GeoPlugin::class,
 
-        Stevebauman\Location\Drivers\MaxMind::class,
+        MaxMind::class,
 
     ],
 
@@ -46,7 +52,7 @@ return [
     |
     */
 
-    'position' => Stevebauman\Location\Position::class,
+    'position' => Position::class,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Utility/Config/urlshortener.php
+++ b/src/Utility/Config/urlshortener.php
@@ -49,7 +49,7 @@ return [
             //     'redirect_code' => 301,
             // ],
             // 'link.company.com' => [
-            //     'prefix' => null, // No prefix - identifier at root
+            //     'prefix' => null, // No prefix - identifier at root (requires resolution_strategy 'host')
             //     'identifier_length' => 8,
             // ],
         ],
@@ -87,6 +87,24 @@ return [
             'decay_minutes' => env('URL_SHORTENER_PASSWORD_DECAY_MINUTES', 1),
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Routing
+    |--------------------------------------------------------------------------
+    |
+    | Additional prefixes that should be registered by the package routes.
+    | Custom prefixes used with withPrefix() must be listed here, or they will
+    | be rejected to avoid returning generated URLs that the package cannot
+    | resolve.
+    |
+    */
+    'routing' => [
+        'additional_prefixes' => [
+            // 'custom',
+        ],
+    ],
+
     /*
     |--------------------------------------------------------------------------
     | URL Validation (Security)
@@ -105,6 +123,11 @@ return [
 
         // Block private/internal IP ranges (SSRF protection)
         'block_private_ips' => env('URL_SHORTENER_BLOCK_PRIVATE_IPS', true),
+
+        // Resolve DNS and reject hosts that resolve to private/reserved IPs.
+        // Opt-in: enabling this performs blocking DNS lookups (no timeout) on
+        // every shorten, so only turn it on when your resolver is reliable.
+        'resolve_dns_private_ips' => env('URL_SHORTENER_RESOLVE_DNS_PRIVATE_IPS', false),
 
         // Additional blocked hosts (e.g., internal services)
         'blocked_hosts' => [

--- a/src/Utility/routes.php
+++ b/src/Utility/routes.php
@@ -4,8 +4,9 @@ use Illuminate\Support\Facades\Route;
 use YorCreative\UrlShortener\Actions\AttemptProtected;
 use YorCreative\UrlShortener\Actions\ShortUrlRedirect;
 use YorCreative\UrlShortener\Middleware\ResolveDomain;
+use YorCreative\UrlShortener\Services\DomainResolver;
 
-$prefix = config('urlshortener.branding.prefix') ?? 'v1';
+$prefixes = app(DomainResolver::class)->getRoutablePrefixes();
 $multiDomainEnabled = config('urlshortener.domains.enabled', false);
 
 // Determine middleware stack
@@ -14,14 +15,56 @@ if ($multiDomainEnabled) {
     $middleware[] = ResolveDomain::class;
 }
 
-Route::middleware($middleware)->group(function () use ($prefix) {
-    Route::get(
-        $prefix.'/{identifier}',
-        ShortUrlRedirect::class
-    );
+Route::middleware($middleware)->group(function () use ($prefixes) {
+    foreach ($prefixes as $prefix) {
+        Route::get(
+            $prefix.'/{identifier}',
+            ShortUrlRedirect::class
+        );
 
-    Route::post(
-        $prefix.'/protected',
-        AttemptProtected::class
-    )->name('urlshortener.attempt.protected');
+        $protectedRoute = Route::post(
+            $prefix.'/protected',
+            AttemptProtected::class
+        );
+
+        if (! Route::has('urlshortener.attempt.protected')) {
+            $protectedRoute->name('urlshortener.attempt.protected');
+        }
+    }
 });
+
+/*
+ * Root-level routes (no prefix) for domains configured with `prefix => null`.
+ *
+ * A prefix-less `{identifier}` route cannot be registered globally without
+ * hijacking every root path of the host application, so it is scoped per-domain
+ * via Route::domain(). This is only meaningful for the `host` resolution
+ * strategy, where the configured host key is the request Host header.
+ */
+if ($multiDomainEnabled
+    && config('urlshortener.domains.resolution_strategy', 'host') === 'host'
+) {
+    foreach (config('urlshortener.domains.hosts', []) as $host => $hostConfig) {
+        $hostPrefix = $hostConfig['prefix'] ?? null;
+
+        if (is_string($hostPrefix) && trim($hostPrefix, '/') !== '') {
+            continue; // Already served by the prefixed routes above.
+        }
+
+        Route::domain($host)->middleware($middleware)->group(function () {
+            Route::get(
+                '{identifier}',
+                ShortUrlRedirect::class
+            );
+
+            $protectedRoute = Route::post(
+                'protected',
+                AttemptProtected::class
+            );
+
+            if (! Route::has('urlshortener.attempt.protected')) {
+                $protectedRoute->name('urlshortener.attempt.protected');
+            }
+        });
+    }
+}

--- a/tests/Feature/AttemptProtectedTest.php
+++ b/tests/Feature/AttemptProtectedTest.php
@@ -2,6 +2,8 @@
 
 namespace YorCreative\UrlShortener\Tests\Feature;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use YorCreative\UrlShortener\Builders\UrlBuilder\UrlBuilder;
 use YorCreative\UrlShortener\Services\ClickService;
 use YorCreative\UrlShortener\Tests\TestCase;
@@ -25,12 +27,9 @@ class AttemptProtectedTest extends TestCase
         $this->protectedIdentifier = $this->extractIdentifier($url);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group AttemptProtected
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('AttemptProtected')]
     public function it_redirects_with_correct_password()
     {
         $response = $this->post(route('urlshortener.attempt.protected'), [
@@ -46,12 +45,9 @@ class AttemptProtectedTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group AttemptProtected
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('AttemptProtected')]
     public function it_returns_404_with_wrong_password()
     {
         $response = $this->post(route('urlshortener.attempt.protected'), [
@@ -67,12 +63,9 @@ class AttemptProtectedTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group AttemptProtected
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('AttemptProtected')]
     public function it_validates_required_identifier()
     {
         $response = $this->post(route('urlshortener.attempt.protected'), [
@@ -83,12 +76,9 @@ class AttemptProtectedTest extends TestCase
         $response->assertSessionHasErrors('identifier');
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group AttemptProtected
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('AttemptProtected')]
     public function it_validates_required_password()
     {
         $response = $this->post(route('urlshortener.attempt.protected'), [
@@ -99,12 +89,9 @@ class AttemptProtectedTest extends TestCase
         $response->assertSessionHasErrors('password');
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group AttemptProtected
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('AttemptProtected')]
     public function it_returns_404_for_nonexistent_identifier()
     {
         $response = $this->post(route('urlshortener.attempt.protected'), [
@@ -115,12 +102,9 @@ class AttemptProtectedTest extends TestCase
         $response->assertStatus(404);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group AttemptProtected
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('AttemptProtected')]
     public function it_works_when_multidomain_is_disabled()
     {
         // Test that protected URL password check works correctly

--- a/tests/Feature/CustomPrefixRouteTest.php
+++ b/tests/Feature/CustomPrefixRouteTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace YorCreative\UrlShortener\Tests\Feature;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use YorCreative\UrlShortener\Builders\UrlBuilder\UrlBuilder;
+use YorCreative\UrlShortener\Tests\TestCase;
+
+class CustomPrefixRouteTest extends TestCase
+{
+    #[Test]
+    #[Group('Feature')]
+    #[Group('CustomPrefix')]
+    public function it_routes_registered_custom_prefix_urls()
+    {
+        config(['urlshortener.routing.additional_prefixes' => ['custom']]);
+
+        require dirname(__DIR__, 2).'/src/Utility/routes.php';
+
+        $plainText = 'https://custom-prefix-destination.com/'.rand(999, 999999);
+        $url = UrlBuilder::shorten($plainText)
+            ->withPrefix('custom')
+            ->build();
+
+        $identifier = $this->extractIdentifier($url);
+
+        $this->get('/custom/'.$identifier)
+            ->assertRedirect($plainText);
+    }
+
+    protected function extractIdentifier(string $url): string
+    {
+        $url = rtrim($url, '/');
+        $parts = explode('/', $url);
+
+        return end($parts);
+    }
+}

--- a/tests/Feature/MultiDomainTest.php
+++ b/tests/Feature/MultiDomainTest.php
@@ -2,7 +2,10 @@
 
 namespace YorCreative\UrlShortener\Tests\Feature;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use YorCreative\UrlShortener\Builders\UrlBuilder\UrlBuilder;
+use YorCreative\UrlShortener\Exceptions\UrlBuilderException;
 use YorCreative\UrlShortener\Models\ShortUrl;
 use YorCreative\UrlShortener\Services\DomainResolver;
 use YorCreative\UrlShortener\Services\UrlService;
@@ -22,12 +25,9 @@ class MultiDomainTest extends TestCase
         ]]);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group MultiDomain
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('MultiDomain')]
     public function it_can_create_short_url_for_specific_domain()
     {
         $url = UrlBuilder::shorten('https://example.com/domain-test')
@@ -41,12 +41,9 @@ class MultiDomainTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group MultiDomain
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('MultiDomain')]
     public function same_identifier_can_exist_on_different_domains()
     {
         // Create short URL on domain A
@@ -78,12 +75,9 @@ class MultiDomainTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group MultiDomain
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('MultiDomain')]
     public function it_can_find_by_identifier_with_domain()
     {
         $identifier = 'test123';
@@ -111,12 +105,9 @@ class MultiDomainTest extends TestCase
         $this->assertEquals('https://destination-b.com', $foundB->plain_text);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group MultiDomain
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('MultiDomain')]
     public function it_uses_domain_specific_identifier_length()
     {
         // test.io is configured with identifier_length = 4
@@ -128,12 +119,52 @@ class MultiDomainTest extends TestCase
         $this->assertEquals(4, strlen($identifier));
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group MultiDomain
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('MultiDomain')]
+    public function it_uses_custom_prefix_override_when_building_domain_url()
+    {
+        config(['urlshortener.routing.additional_prefixes' => ['custom']]);
+
+        $url = UrlBuilder::shorten('https://example.com/prefix-override')
+            ->forDomain('test.io')
+            ->withPrefix('custom')
+            ->build();
+
+        $this->assertStringStartsWith('https://test.io/custom/', $url);
+    }
+
+    #[Test]
+    #[Group('Feature')]
+    #[Group('MultiDomain')]
+    public function it_rejects_unregistered_custom_prefix_override()
+    {
+        $this->expectException(UrlBuilderException::class);
+        $this->expectExceptionMessage('not registered');
+
+        UrlBuilder::shorten('https://example.com/unregistered-prefix')
+            ->forDomain('test.io')
+            ->withPrefix('custom')
+            ->build();
+    }
+
+    #[Test]
+    #[Group('Feature')]
+    #[Group('MultiDomain')]
+    public function it_rejects_empty_custom_prefix_override()
+    {
+        $this->expectException(UrlBuilderException::class);
+        $this->expectExceptionMessage('cannot be empty');
+
+        UrlBuilder::shorten('https://example.com/empty-prefix')
+            ->forDomain('test.io')
+            ->withPrefix('')
+            ->build();
+    }
+
+    #[Test]
+    #[Group('Feature')]
+    #[Group('MultiDomain')]
     public function domain_resolver_builds_correct_url()
     {
         $resolver = app(DomainResolver::class);
@@ -145,12 +176,9 @@ class MultiDomainTest extends TestCase
         $this->assertEquals('https://link.co/l/xyz789', $url);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group MultiDomain
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('MultiDomain')]
     public function it_can_find_all_urls_by_domain()
     {
         ShortUrl::create([
@@ -181,12 +209,9 @@ class MultiDomainTest extends TestCase
         $this->assertEquals(1, $linkCoUrls->count());
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group MultiDomain
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('MultiDomain')]
     public function it_works_in_single_domain_mode_when_disabled()
     {
         // Disable multi-domain
@@ -205,12 +230,9 @@ class MultiDomainTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group MultiDomain
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('MultiDomain')]
     public function find_or_create_respects_domain()
     {
         // Create a URL on test.io domain
@@ -225,6 +247,36 @@ class MultiDomainTest extends TestCase
         // findOrCreate with same URL but different domain should return builder
         $result = UrlService::findOrCreate('https://example.com/findorcreate', 'link.co');
         $this->assertInstanceOf(UrlBuilder::class, $result);
+    }
+
+    #[Test]
+    #[Group('Feature')]
+    #[Group('MultiDomain')]
+    public function it_routes_root_level_urls_for_domains_without_a_prefix()
+    {
+        config(['urlshortener.domains.enabled' => true]);
+        config(['urlshortener.domains.resolution_strategy' => 'host']);
+        config(['urlshortener.domains.hosts' => [
+            'root.test' => ['prefix' => null, 'identifier_length' => 6],
+        ]]);
+
+        require dirname(__DIR__, 2).'/src/Utility/routes.php';
+
+        $plainText = 'https://root-destination.com/'.rand(999, 999999);
+        $url = UrlBuilder::shorten($plainText)
+            ->forDomain('root.test')
+            ->build();
+
+        // The URL is generated at the host root, with no prefix segment.
+        $this->assertStringStartsWith('https://root.test/', $url);
+
+        $identifier = $this->extractIdentifier($url);
+
+        $this->assertStringNotContainsString('/', trim(str_replace('https://root.test/', '', $url), '/'));
+
+        // The generated root-level URL must actually resolve.
+        $this->get('https://root.test/'.$identifier)
+            ->assertRedirect($plainText);
     }
 
     /**

--- a/tests/Feature/ShortUrlBasicTest.php
+++ b/tests/Feature/ShortUrlBasicTest.php
@@ -2,16 +2,15 @@
 
 namespace YorCreative\UrlShortener\Tests\Feature;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use YorCreative\UrlShortener\Services\UrlService;
 use YorCreative\UrlShortener\Tests\TestCase;
 
 class ShortUrlBasicTest extends TestCase
 {
-    /**
-     * @test
-     *
-     * @group Feature
-     */
+    #[Test]
+    #[Group('Feature')]
     public function it_can_create_a_basic_short_url()
     {
         $this->assertDatabaseHas(
@@ -38,11 +37,8 @@ class ShortUrlBasicTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     */
+    #[Test]
+    #[Group('Feature')]
     public function it_returns_404_for_nonexistent_identifier()
     {
         $prefix = config('urlshortener.branding.prefix') ?? 'v1';
@@ -51,11 +47,8 @@ class ShortUrlBasicTest extends TestCase
         $response->assertStatus(404);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     */
+    #[Test]
+    #[Group('Feature')]
     public function it_can_redirect_to_short_url()
     {
         // Create a fresh short URL in this test

--- a/tests/Feature/ShortUrlClickTest.php
+++ b/tests/Feature/ShortUrlClickTest.php
@@ -3,6 +3,8 @@
 namespace YorCreative\UrlShortener\Tests\Feature;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Throwable;
 use YorCreative\UrlShortener\Exceptions\UrlRepositoryException;
 use YorCreative\UrlShortener\Models\ShortUrlClick;
@@ -15,13 +17,11 @@ class ShortUrlClickTest extends TestCase
     use DatabaseTransactions;
 
     /**
-     * @test
-     *
-     * @group Feature
-     *
      * @throws UrlRepositoryException
      * @throws Throwable
      */
+    #[Test]
+    #[Group('Feature')]
     public function it_can_track_and_retrieve_successfully_routed_clicks()
     {
         // 5 successful routed
@@ -63,13 +63,11 @@ class ShortUrlClickTest extends TestCase
     }
 
     /**
-     * @test
-     *
-     * @group Feature
-     *
      * @throws UrlRepositoryException
      * @throws Throwable
      */
+    #[Test]
+    #[Group('Feature')]
     public function it_can_successfully_routed_clicks_while_filtering_for_utm_source()
     {
         // 3 successful routed

--- a/tests/Feature/ShortUrlRedirectFailureTest.php
+++ b/tests/Feature/ShortUrlRedirectFailureTest.php
@@ -3,7 +3,12 @@
 namespace YorCreative\UrlShortener\Tests\Feature;
 
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use YorCreative\UrlShortener\Builders\UrlBuilder\UrlBuilder;
+use YorCreative\UrlShortener\Events\ShortUrlExpired;
 use YorCreative\UrlShortener\Models\ShortUrl;
 use YorCreative\UrlShortener\Models\ShortUrlLocation;
 use YorCreative\UrlShortener\Services\ClickService;
@@ -22,12 +27,9 @@ class ShortUrlRedirectFailureTest extends TestCase
         ShortUrlLocation::firstOrCreate(['ip' => '127.0.0.1']);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group ShortUrlRedirect
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('ShortUrlRedirect')]
     public function it_returns_404_for_expired_url()
     {
         $plainText = 'https://expired-destination.com/'.rand(999, 999999);
@@ -51,12 +53,9 @@ class ShortUrlRedirectFailureTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group ShortUrlRedirect
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('ShortUrlRedirect')]
     public function it_returns_404_for_not_yet_activated_url()
     {
         $plainText = 'https://future-activation.com/'.rand(999, 999999);
@@ -78,12 +77,9 @@ class ShortUrlRedirectFailureTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group ShortUrlRedirect
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('ShortUrlRedirect')]
     public function it_returns_404_when_click_limit_reached()
     {
         $plainText = 'https://limited-clicks.com/'.rand(999, 999999);
@@ -113,12 +109,38 @@ class ShortUrlRedirectFailureTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group ShortUrlRedirect
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('ShortUrlRedirect')]
+    public function it_treats_a_zero_limit_as_unlimited()
+    {
+        $plainText = 'https://zero-limit.com/'.rand(999, 999999);
+
+        $url = UrlBuilder::shorten($plainText)->build();
+        $identifier = $this->extractIdentifier($url);
+
+        // Simulate a legacy/direct row that stored 0 (rather than null) for limit.
+        ShortUrl::where('identifier', $identifier)->update(['limit' => 0]);
+
+        $shortUrl = ShortUrl::where('identifier', $identifier)->first();
+        $shortUrl->clicks()->create([
+            'location_id' => 1,
+            'outcome_id' => ClickService::$SUCCESS_ROUTED,
+        ]);
+
+        // A limit of 0 means unlimited, so this should still redirect.
+        $this->get($this->prefix.'/'.$identifier)
+            ->assertRedirect($plainText);
+
+        $this->assertDatabaseMissing('short_url_clicks', [
+            'short_url_id' => $shortUrl->id,
+            'outcome_id' => ClickService::$FAILURE_LIMIT,
+        ]);
+    }
+
+    #[Test]
+    #[Group('Feature')]
+    #[Group('ShortUrlRedirect')]
     public function it_tracks_protected_click_for_password_protected_url()
     {
         $plainText = 'https://password-protected.com/'.rand(999, 999999);
@@ -145,12 +167,9 @@ class ShortUrlRedirectFailureTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group ShortUrlRedirect
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('ShortUrlRedirect')]
     public function it_successfully_redirects_active_url()
     {
         $plainText = 'https://active-destination.com/'.rand(999, 999999);
@@ -168,12 +187,61 @@ class ShortUrlRedirectFailureTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group ShortUrlRedirect
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('ShortUrlRedirect')]
+    public function it_tracks_successful_redirect_without_reloading_short_url()
+    {
+        $plainText = 'https://active-destination-lookup.com/'.rand(999, 999999);
+
+        $url = UrlBuilder::shorten($plainText)->build();
+        $identifier = $this->extractIdentifier($url);
+
+        $queries = [];
+        DB::listen(function ($query) use (&$queries) {
+            $queries[] = $query->sql;
+        });
+
+        $response = $this->get($this->prefix.'/'.$identifier);
+
+        $response->assertRedirect($plainText);
+
+        $shortUrlQueries = array_filter($queries, function ($sql) {
+            return str_contains($sql, 'from "short_urls"')
+                || str_contains($sql, 'from `short_urls`');
+        });
+
+        $this->assertCount(1, $shortUrlQueries);
+    }
+
+    #[Test]
+    #[Group('Feature')]
+    #[Group('ShortUrlRedirect')]
+    public function it_dispatches_expired_event_with_full_short_url_payload()
+    {
+        $plainText = 'https://expired-event-payload.com/'.rand(999, 999999);
+
+        $url = UrlBuilder::shorten($plainText)->build();
+        $identifier = $this->extractIdentifier($url);
+
+        ShortUrl::where('identifier', $identifier)
+            ->update(['expiration' => Carbon::now()->subHour()->timestamp]);
+
+        Event::fake([ShortUrlExpired::class]);
+
+        $this->get($this->prefix.'/'.$identifier);
+
+        Event::assertDispatched(ShortUrlExpired::class, function (ShortUrlExpired $event) use ($plainText) {
+            return $event->shortUrl->plain_text === $plainText
+                && $event->shortUrl->relationLoaded('ownership')
+                && $event->shortUrl->relationLoaded('clicks')
+                && $event->shortUrl->relationLoaded('tracing');
+        });
+    }
+
+    #[Test]
+    #[Group('Feature')]
+    #[Group('ShortUrlRedirect')]
     public function it_allows_access_when_activation_time_passed()
     {
         $plainText = 'https://now-active.com/'.rand(999, 999999);
@@ -190,12 +258,9 @@ class ShortUrlRedirectFailureTest extends TestCase
         $response->assertRedirect($plainText);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group ShortUrlRedirect
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('ShortUrlRedirect')]
     public function it_allows_access_when_under_click_limit()
     {
         $plainText = 'https://under-limit.com/'.rand(999, 999999);
@@ -212,12 +277,9 @@ class ShortUrlRedirectFailureTest extends TestCase
         $response->assertRedirect($plainText);
     }
 
-    /**
-     * @test
-     *
-     * @group Feature
-     * @group ShortUrlRedirect
-     */
+    #[Test]
+    #[Group('Feature')]
+    #[Group('ShortUrlRedirect')]
     public function it_tracks_all_outcome_types_correctly()
     {
         // Test that all 6 outcome types can be stored

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace YorCreative\UrlShortener\Tests;
 
+use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
@@ -94,7 +95,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
     /**
      * Define environment setup.
      *
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
      * @return void
      */
     protected function defineEnvironment($app)

--- a/tests/Unit/Builders/UrlBuilder/VanityIdentifierTest.php
+++ b/tests/Unit/Builders/UrlBuilder/VanityIdentifierTest.php
@@ -3,6 +3,8 @@
 namespace YorCreative\UrlShortener\Tests\Unit\Builders\UrlBuilder;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use YorCreative\UrlShortener\Builders\UrlBuilder\UrlBuilder;
 use YorCreative\UrlShortener\Exceptions\UrlBuilderException;
 use YorCreative\UrlShortener\Tests\TestCase;
@@ -11,11 +13,8 @@ class VanityIdentifierTest extends TestCase
 {
     use DatabaseTransactions;
 
-    /**
-     * @test
-     *
-     * @group UrlBuilder
-     */
+    #[Test]
+    #[Group('UrlBuilder')]
     public function it_can_build_short_url_with_custom_identifier()
     {
         $plainText = 'https://example.com/vanity-test/'.rand(999, 999999);
@@ -32,11 +31,8 @@ class VanityIdentifierTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     *
-     * @group UrlBuilder
-     */
+    #[Test]
+    #[Group('UrlBuilder')]
     public function it_rejects_empty_identifier()
     {
         $this->expectException(UrlBuilderException::class);
@@ -45,11 +41,8 @@ class VanityIdentifierTest extends TestCase
             ->withIdentifier('');
     }
 
-    /**
-     * @test
-     *
-     * @group UrlBuilder
-     */
+    #[Test]
+    #[Group('UrlBuilder')]
     public function it_rejects_identifier_exceeding_max_length()
     {
         $this->expectException(UrlBuilderException::class);
@@ -58,11 +51,8 @@ class VanityIdentifierTest extends TestCase
             ->withIdentifier(str_repeat('a', 256));
     }
 
-    /**
-     * @test
-     *
-     * @group UrlBuilder
-     */
+    #[Test]
+    #[Group('UrlBuilder')]
     public function it_rejects_identifier_with_invalid_characters()
     {
         $this->expectException(UrlBuilderException::class);
@@ -71,11 +61,8 @@ class VanityIdentifierTest extends TestCase
             ->withIdentifier('my slug with spaces');
     }
 
-    /**
-     * @test
-     *
-     * @group UrlBuilder
-     */
+    #[Test]
+    #[Group('UrlBuilder')]
     public function it_rejects_duplicate_custom_identifier()
     {
         $plainText1 = 'https://example.com/dup-test-1/'.rand(999, 999999);

--- a/tests/Unit/Events/ShortUrlEventsTest.php
+++ b/tests/Unit/Events/ShortUrlEventsTest.php
@@ -5,6 +5,8 @@ namespace YorCreative\UrlShortener\Tests\Unit\Events;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use YorCreative\UrlShortener\Builders\UrlBuilder\UrlBuilder;
 use YorCreative\UrlShortener\Events\ShortUrlClicked;
 use YorCreative\UrlShortener\Events\ShortUrlCreated;
@@ -18,11 +20,8 @@ class ShortUrlEventsTest extends TestCase
 {
     use DatabaseTransactions;
 
-    /**
-     * @test
-     *
-     * @group Events
-     */
+    #[Test]
+    #[Group('Events')]
     public function it_dispatches_short_url_created_event_on_build()
     {
         Event::fake([ShortUrlCreated::class]);
@@ -36,11 +35,8 @@ class ShortUrlEventsTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     *
-     * @group Events
-     */
+    #[Test]
+    #[Group('Events')]
     public function it_dispatches_short_url_clicked_event_on_track()
     {
         Event::fake([ShortUrlClicked::class]);
@@ -60,11 +56,8 @@ class ShortUrlEventsTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     *
-     * @group Events
-     */
+    #[Test]
+    #[Group('Events')]
     public function it_dispatches_short_url_expired_event_on_expired_redirect()
     {
         Event::fake([ShortUrlExpired::class]);

--- a/tests/Unit/Middleware/ResolveDomainTest.php
+++ b/tests/Unit/Middleware/ResolveDomainTest.php
@@ -3,6 +3,8 @@
 namespace YorCreative\UrlShortener\Tests\Unit\Middleware;
 
 use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use YorCreative\UrlShortener\Middleware\ResolveDomain;
 use YorCreative\UrlShortener\Services\DomainResolver;
@@ -18,12 +20,9 @@ class ResolveDomainTest extends TestCase
         $this->middleware = new ResolveDomain(new DomainResolver);
     }
 
-    /**
-     * @test
-     *
-     * @group Middleware
-     * @group ResolveDomain
-     */
+    #[Test]
+    #[Group('Middleware')]
+    #[Group('ResolveDomain')]
     public function it_passes_through_when_domains_disabled()
     {
         config(['urlshortener.domains.enabled' => false]);
@@ -41,12 +40,9 @@ class ResolveDomainTest extends TestCase
         $this->assertNull($request->attributes->get('urlshortener_domain'));
     }
 
-    /**
-     * @test
-     *
-     * @group Middleware
-     * @group ResolveDomain
-     */
+    #[Test]
+    #[Group('Middleware')]
+    #[Group('ResolveDomain')]
     public function it_sets_domain_attribute_on_request()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -68,12 +64,9 @@ class ResolveDomainTest extends TestCase
         $this->assertEquals('test.io', $request->attributes->get('urlshortener_domain'));
     }
 
-    /**
-     * @test
-     *
-     * @group Middleware
-     * @group ResolveDomain
-     */
+    #[Test]
+    #[Group('Middleware')]
+    #[Group('ResolveDomain')]
     public function it_aborts_for_unallowed_domain_when_validation_enabled()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -92,12 +85,9 @@ class ResolveDomainTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     *
-     * @group Middleware
-     * @group ResolveDomain
-     */
+    #[Test]
+    #[Group('Middleware')]
+    #[Group('ResolveDomain')]
     public function it_allows_any_domain_when_validation_disabled()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -119,12 +109,9 @@ class ResolveDomainTest extends TestCase
         $this->assertTrue($called);
     }
 
-    /**
-     * @test
-     *
-     * @group Middleware
-     * @group ResolveDomain
-     */
+    #[Test]
+    #[Group('Middleware')]
+    #[Group('ResolveDomain')]
     public function it_handles_null_domain_gracefully()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -144,12 +131,9 @@ class ResolveDomainTest extends TestCase
         $this->assertNull($request->attributes->get('urlshortener_domain'));
     }
 
-    /**
-     * @test
-     *
-     * @group Middleware
-     * @group ResolveDomain
-     */
+    #[Test]
+    #[Group('Middleware')]
+    #[Group('ResolveDomain')]
     public function it_resolves_domain_aliases()
     {
         config(['urlshortener.domains.enabled' => true]);

--- a/tests/Unit/Repositories/ClickRepositoryTest.php
+++ b/tests/Unit/Repositories/ClickRepositoryTest.php
@@ -3,6 +3,8 @@
 namespace YorCreative\UrlShortener\Tests\Unit\Repositories;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use YorCreative\UrlShortener\Builders\UrlBuilder\UrlBuilder;
 use YorCreative\UrlShortener\Exceptions\ClickRepositoryException;
 use YorCreative\UrlShortener\Models\ShortUrlClick;
@@ -14,11 +16,8 @@ class ClickRepositoryTest extends TestCase
 {
     use DatabaseTransactions;
 
-    /**
-     * @test
-     *
-     * @group ClickRepository
-     */
+    #[Test]
+    #[Group('ClickRepository')]
     public function it_can_find_a_click_by_its_id()
     {
         ClickService::track(
@@ -34,11 +33,8 @@ class ClickRepositoryTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     *
-     * @group ClickRepository
-     */
+    #[Test]
+    #[Group('ClickRepository')]
     public function it_can_create_a_click_in_db()
     {
         ClickRepository::createClick(
@@ -57,11 +53,8 @@ class ClickRepositoryTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     *
-     * @group ClickRepository
-     */
+    #[Test]
+    #[Group('ClickRepository')]
     public function it_can_get_correct_with_default_relations()
     {
         $this->assertEquals([
@@ -69,11 +62,8 @@ class ClickRepositoryTest extends TestCase
         ], ClickRepository::defaultWithRelations());
     }
 
-    /**
-     * @test
-     *
-     * @group ClickRepository
-     */
+    #[Test]
+    #[Group('ClickRepository')]
     public function it_can_find_click_for_domain_when_multidomain_disabled()
     {
         config(['urlshortener.domains.enabled' => false]);
@@ -93,11 +83,8 @@ class ClickRepositoryTest extends TestCase
         $this->assertEquals($click->id, $foundClick->id);
     }
 
-    /**
-     * @test
-     *
-     * @group ClickRepository
-     */
+    #[Test]
+    #[Group('ClickRepository')]
     public function it_filters_click_by_domain_when_multidomain_enabled()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -129,11 +116,8 @@ class ClickRepositoryTest extends TestCase
         ClickRepository::findByIdForDomain($click->id, 'domain2.io');
     }
 
-    /**
-     * @test
-     *
-     * @group ClickRepository
-     */
+    #[Test]
+    #[Group('ClickRepository')]
     public function it_throws_exception_for_nonexistent_click_id()
     {
         $this->expectException(ClickRepositoryException::class);

--- a/tests/Unit/Repositories/LocationRepositoryTest.php
+++ b/tests/Unit/Repositories/LocationRepositoryTest.php
@@ -2,17 +2,16 @@
 
 namespace YorCreative\UrlShortener\Tests\Unit\Repositories;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use YorCreative\UrlShortener\Models\ShortUrlLocation;
 use YorCreative\UrlShortener\Repositories\LocationRepository;
 use YorCreative\UrlShortener\Tests\TestCase;
 
 class LocationRepositoryTest extends TestCase
 {
-    /**
-     * @test
-     *
-     * @group LocationRepository
-     */
+    #[Test]
+    #[Group('LocationRepository')]
     public function it_can_find_location_by_ip()
     {
         $location = ShortUrlLocation::create([
@@ -27,11 +26,8 @@ class LocationRepositoryTest extends TestCase
         $this->assertEquals('192.168.1.100', $found->ip);
     }
 
-    /**
-     * @test
-     *
-     * @group LocationRepository
-     */
+    #[Test]
+    #[Group('LocationRepository')]
     public function it_returns_null_for_unknown_ip()
     {
         $found = LocationRepository::findIp('10.0.0.1');
@@ -39,11 +35,8 @@ class LocationRepositoryTest extends TestCase
         $this->assertNull($found);
     }
 
-    /**
-     * @test
-     *
-     * @group LocationRepository
-     */
+    #[Test]
+    #[Group('LocationRepository')]
     public function it_creates_new_location_record()
     {
         $locationData = [
@@ -67,11 +60,8 @@ class LocationRepositoryTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     *
-     * @group LocationRepository
-     */
+    #[Test]
+    #[Group('LocationRepository')]
     public function it_finds_existing_location_record()
     {
         // Create existing location
@@ -91,11 +81,8 @@ class LocationRepositoryTest extends TestCase
         $this->assertEquals($existing->id, $found->id);
     }
 
-    /**
-     * @test
-     *
-     * @group LocationRepository
-     */
+    #[Test]
+    #[Group('LocationRepository')]
     public function it_creates_location_with_only_ip()
     {
         $locationData = ['ip' => '172.16.0.1'];
@@ -110,11 +97,8 @@ class LocationRepositoryTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     *
-     * @group LocationRepository
-     */
+    #[Test]
+    #[Group('LocationRepository')]
     public function it_returns_unknown_location_array()
     {
         $result = LocationRepository::locationUnknown('10.20.30.40');
@@ -125,11 +109,8 @@ class LocationRepositoryTest extends TestCase
         $this->assertCount(1, $result);
     }
 
-    /**
-     * @test
-     *
-     * @group LocationRepository
-     */
+    #[Test]
+    #[Group('LocationRepository')]
     public function it_handles_partial_location_data()
     {
         // Location with country but no region
@@ -144,11 +125,8 @@ class LocationRepositoryTest extends TestCase
         $this->assertEquals('FR', $location->countryCode);
     }
 
-    /**
-     * @test
-     *
-     * @group LocationRepository
-     */
+    #[Test]
+    #[Group('LocationRepository')]
     public function it_differentiates_locations_by_region()
     {
         // Create location for same IP but different regions

--- a/tests/Unit/Repositories/TracingRepositoryTest.php
+++ b/tests/Unit/Repositories/TracingRepositoryTest.php
@@ -4,6 +4,8 @@ namespace YorCreative\UrlShortener\Tests\Unit\Repositories;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use ReflectionClass;
 use ReflectionException;
 use YorCreative\UrlShortener\Models\ShortUrl;
@@ -15,12 +17,10 @@ class TracingRepositoryTest extends TestCase
     use DatabaseTransactions;
 
     /**
-     * @test
-     *
-     * @group TracingRepository
-     *
      * @throws ReflectionException
      */
+    #[Test]
+    #[Group('TracingRepository')]
     public function it_can_detect_all_utm_parameters()
     {
         foreach ($this->getAllowedParameters() as $parameter) {
@@ -54,12 +54,10 @@ class TracingRepositoryTest extends TestCase
     }
 
     /**
-     * @test
-     *
-     * @group TracingRepository
-     *
      * @throws ReflectionException
      */
+    #[Test]
+    #[Group('TracingRepository')]
     public function it_has_correct_allowed_parameters()
     {
         foreach ($this->getAllowedParameters() as $parameter) {
@@ -76,11 +74,8 @@ class TracingRepositoryTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     *
-     * @group TracingRepository
-     */
+    #[Test]
+    #[Group('TracingRepository')]
     public function it_can_create_a_trace_record()
     {
         $utm_query = [

--- a/tests/Unit/Repositories/UrlRepositoryTest.php
+++ b/tests/Unit/Repositories/UrlRepositoryTest.php
@@ -4,6 +4,8 @@ namespace YorCreative\UrlShortener\Tests\Unit\Repositories;
 
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use YorCreative\UrlShortener\Models\ShortUrlOwnership;
 use YorCreative\UrlShortener\Repositories\UrlRepository;
 use YorCreative\UrlShortener\Tests\TestCase;
@@ -12,11 +14,8 @@ class UrlRepositoryTest extends TestCase
 {
     use DatabaseTransactions;
 
-    /**
-     * @test
-     *
-     * @group UrlRepository
-     */
+    #[Test]
+    #[Group('UrlRepository')]
     public function it_can_find_ownership_record()
     {
         $ownerable = ShortUrlOwnership::factory()->create();
@@ -30,11 +29,8 @@ class UrlRepositoryTest extends TestCase
         $this->assertTrue($ownerable->id == $record->id);
     }
 
-    /**
-     * @test
-     *
-     * @group UrlRepository
-     */
+    #[Test]
+    #[Group('UrlRepository')]
     public function it_can_create_ownership_record()
     {
         $ownerable = [
@@ -50,22 +46,16 @@ class UrlRepositoryTest extends TestCase
         $this->assertDatabaseHas('short_url_ownerships', $ownerable);
     }
 
-    /**
-     * @test
-     *
-     * @group UrlRepository
-     */
+    #[Test]
+    #[Group('UrlRepository')]
     public function it_can_find_short_url_by_hash()
     {
         $shortUrl = UrlRepository::findByHash($this->hashed);
         $this->assertTrue($shortUrl->id == $this->shortUrl->id);
     }
 
-    /**
-     * @test
-     *
-     * @group UrlRepository
-     */
+    #[Test]
+    #[Group('UrlRepository')]
     public function it_can_create_a_short_url()
     {
         $plain_text = $this->plain_text.rand(9, 3333);
@@ -85,11 +75,8 @@ class UrlRepositoryTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     *
-     * @group UrlRepository
-     */
+    #[Test]
+    #[Group('UrlRepository')]
     public function it_can_update_a_short_url()
     {
         $this->assertNull($this->shortUrl->activation);
@@ -103,11 +90,8 @@ class UrlRepositoryTest extends TestCase
         $this->assertNotNull($shortUrl->activation);
     }
 
-    /**
-     * @test
-     *
-     * @group UrlRepository
-     */
+    #[Test]
+    #[Group('UrlRepository')]
     public function it_can_bool_that_identifier_exists()
     {
         $this->assertFalse(UrlRepository::identifierExists($this->identifier.'333'));

--- a/tests/Unit/Services/ClickServiceTest.php
+++ b/tests/Unit/Services/ClickServiceTest.php
@@ -2,10 +2,15 @@
 
 namespace YorCreative\UrlShortener\Tests\Unit\Services;
 
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Throwable;
 use YorCreative\UrlShortener\Exceptions\FilterClicksStrategyException;
 use YorCreative\UrlShortener\Exceptions\UrlRepositoryException;
+use YorCreative\UrlShortener\Models\ShortUrl;
+use YorCreative\UrlShortener\Models\ShortUrlClick;
 use YorCreative\UrlShortener\Repositories\LocationRepository;
 use YorCreative\UrlShortener\Services\ClickService;
 use YorCreative\UrlShortener\Tests\TestCase;
@@ -14,11 +19,8 @@ class ClickServiceTest extends TestCase
 {
     use DatabaseTransactions;
 
-    /**
-     * @test
-     *
-     * @group ClickService
-     */
+    #[Test]
+    #[Group('ClickService')]
     public function it_can_can_track_a_click()
     {
         $ip = '0.0.0.0';
@@ -47,14 +49,12 @@ class ClickServiceTest extends TestCase
     }
 
     /**
-     * @test
-     *
-     * @group ClickService
-     *
      * @throws UrlRepositoryException
      * @throws Throwable
      * @throws FilterClicksStrategyException
      */
+    #[Test]
+    #[Group('ClickService')]
     public function it_can_get_basic_scoped_clicks_for_short_url()
     {
         $ip = '0.0.0.0';
@@ -85,5 +85,173 @@ class ClickServiceTest extends TestCase
         $this->assertArrayHasKey('created_at', $click);
         $this->assertArrayHasKey('short_url', $click);
         $this->assertArrayHasKey('tracing', $click['short_url']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Test]
+    #[Group('ClickService')]
+    public function it_can_filter_failure_activation_clicks()
+    {
+        $shortUrl = $this->createClickedShortUrl(null, ClickService::$FAILURE_ACTIVATION);
+
+        $clicks = ClickService::get([
+            'outcome' => [
+                ClickService::$FAILURE_ACTIVATION,
+            ],
+        ]);
+
+        $this->assertCount(1, $clicks['results']);
+        $this->assertSame($shortUrl->identifier, $clicks['results']->first()->shortUrl->identifier);
+        $this->assertSame(ClickService::$FAILURE_ACTIVATION, $clicks['results']->first()->outcome->id);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Test]
+    #[Group('ClickService')]
+    public function it_treats_non_expiring_urls_as_active()
+    {
+        $shortUrl = $this->createClickedShortUrl(null);
+
+        $clicks = ClickService::get([
+            'status' => [
+                'active',
+            ],
+        ]);
+
+        $this->assertTrue(
+            $clicks['results']->contains(fn ($click) => $click->shortUrl->identifier === $shortUrl->identifier)
+        );
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Test]
+    #[Group('ClickService')]
+    public function it_treats_future_expiration_urls_as_active()
+    {
+        Carbon::setTestNow(Carbon::parse('2026-01-01 12:00:00'));
+
+        try {
+            $shortUrl = $this->createClickedShortUrl(now()->addHour()->timestamp);
+
+            $clicks = ClickService::get([
+                'status' => [
+                    'active',
+                ],
+            ]);
+
+            $this->assertTrue(
+                $clicks['results']->contains(fn ($click) => $click->shortUrl->identifier === $shortUrl->identifier)
+            );
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Test]
+    #[Group('ClickService')]
+    public function it_filters_expired_urls()
+    {
+        Carbon::setTestNow(Carbon::parse('2026-01-01 12:00:00'));
+
+        try {
+            $expired = $this->createClickedShortUrl(now()->subHour()->timestamp);
+            $active = $this->createClickedShortUrl(now()->addHour()->timestamp);
+
+            $clicks = ClickService::get([
+                'status' => [
+                    'expired',
+                ],
+            ]);
+
+            $this->assertTrue(
+                $clicks['results']->contains(fn ($click) => $click->shortUrl->identifier === $expired->identifier)
+            );
+            $this->assertFalse(
+                $clicks['results']->contains(fn ($click) => $click->shortUrl->identifier === $active->identifier)
+            );
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Test]
+    #[Group('ClickService')]
+    public function it_filters_expiring_urls()
+    {
+        Carbon::setTestNow(Carbon::parse('2026-01-01 12:00:00'));
+
+        try {
+            $expiring = $this->createClickedShortUrl(now()->addMinutes(10)->timestamp);
+            $later = $this->createClickedShortUrl(now()->addHour()->timestamp);
+
+            $clicks = ClickService::get([
+                'status' => [
+                    'expiring',
+                ],
+            ]);
+
+            $this->assertTrue(
+                $clicks['results']->contains(fn ($click) => $click->shortUrl->identifier === $expiring->identifier)
+            );
+            $this->assertFalse(
+                $clicks['results']->contains(fn ($click) => $click->shortUrl->identifier === $later->identifier)
+            );
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Test]
+    #[Group('ClickService')]
+    public function it_treats_a_url_expiring_exactly_now_as_expired()
+    {
+        Carbon::setTestNow(Carbon::parse('2026-01-01 12:00:00'));
+
+        try {
+            // A URL whose expiration is exactly the current second is expired,
+            // matching the redirect flow (now >= expiration).
+            $boundary = $this->createClickedShortUrl(now()->timestamp);
+
+            $expired = ClickService::get(['status' => ['expired']]);
+            $active = ClickService::get(['status' => ['active']]);
+
+            $this->assertTrue(
+                $expired['results']->contains(fn ($click) => $click->shortUrl->identifier === $boundary->identifier)
+            );
+            $this->assertFalse(
+                $active['results']->contains(fn ($click) => $click->shortUrl->identifier === $boundary->identifier)
+            );
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    protected function createClickedShortUrl(?int $expiration, int $outcomeId = 1): ShortUrl
+    {
+        $shortUrl = ShortUrl::factory()->create([
+            'expiration' => $expiration,
+        ]);
+
+        ShortUrlClick::factory()->create([
+            'short_url_id' => $shortUrl->id,
+            'outcome_id' => $outcomeId,
+        ]);
+
+        return $shortUrl;
     }
 }

--- a/tests/Unit/Services/DomainResolverTest.php
+++ b/tests/Unit/Services/DomainResolverTest.php
@@ -3,6 +3,9 @@
 namespace YorCreative\UrlShortener\Tests\Unit\Services;
 
 use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use YorCreative\UrlShortener\Contracts\DomainResolverInterface;
 use YorCreative\UrlShortener\Exceptions\DomainResolutionException;
 use YorCreative\UrlShortener\Services\DomainResolver;
 use YorCreative\UrlShortener\Tests\TestCase;
@@ -17,11 +20,8 @@ class DomainResolverTest extends TestCase
         $this->resolver = new DomainResolver;
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_returns_null_when_domains_disabled()
     {
         config(['urlshortener.domains.enabled' => false]);
@@ -32,11 +32,8 @@ class DomainResolverTest extends TestCase
         $this->assertNull($result);
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_resolves_domain_from_host_strategy()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -48,11 +45,8 @@ class DomainResolverTest extends TestCase
         $this->assertEquals('test.io', $result);
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_strips_www_prefix_from_host()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -64,11 +58,8 @@ class DomainResolverTest extends TestCase
         $this->assertEquals('test.io', $result);
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_resolves_domain_from_subdomain_strategy()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -81,11 +72,8 @@ class DomainResolverTest extends TestCase
         $this->assertEquals('test', $result);
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_returns_null_for_subdomain_without_base_domain()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -98,11 +86,8 @@ class DomainResolverTest extends TestCase
         $this->assertNull($result);
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_resolves_domain_from_path_strategy()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -114,11 +99,8 @@ class DomainResolverTest extends TestCase
         $this->assertEquals('mycompany', $result);
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_resolves_domain_aliases()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -133,11 +115,8 @@ class DomainResolverTest extends TestCase
         $this->assertEquals('test.io', $result);
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_throws_exception_for_unknown_strategy()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -150,11 +129,8 @@ class DomainResolverTest extends TestCase
         $this->resolver->resolve($request);
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_builds_url_with_protocol()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -169,11 +145,8 @@ class DomainResolverTest extends TestCase
         $this->assertStringContainsString('abc123', $url);
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_builds_url_with_prefix()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -186,11 +159,23 @@ class DomainResolverTest extends TestCase
         $this->assertEquals('https://test.io/go/abc123', $url);
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
+    public function it_builds_url_with_a_numeric_zero_prefix()
+    {
+        config(['urlshortener.domains.enabled' => true]);
+        config(['urlshortener.domains.hosts' => [
+            'test.io' => ['prefix' => '0'],
+        ]]);
+
+        $url = $this->resolver->buildUrl('abc123', 'test.io');
+
+        // A "0" prefix is a valid, routable segment and must not be dropped.
+        $this->assertEquals('https://test.io/0/abc123', $url);
+    }
+
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_builds_url_without_prefix()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -203,11 +188,8 @@ class DomainResolverTest extends TestCase
         $this->assertEquals('https://test.io/abc123', $url);
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_checks_if_domain_is_allowed_when_disabled()
     {
         config(['urlshortener.domains.enabled' => false]);
@@ -215,11 +197,8 @@ class DomainResolverTest extends TestCase
         $this->assertTrue($this->resolver->isAllowed('any-domain.com'));
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_checks_if_domain_is_allowed_from_config()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -232,11 +211,8 @@ class DomainResolverTest extends TestCase
         $this->assertFalse($this->resolver->isAllowed('not-allowed.io'));
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_allows_null_domain_as_default()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -244,11 +220,8 @@ class DomainResolverTest extends TestCase
         $this->assertTrue($this->resolver->isAllowed(null));
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_gets_prefix_for_domain()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -259,11 +232,8 @@ class DomainResolverTest extends TestCase
         $this->assertEquals('myprefix', $this->resolver->getPrefix('test.io'));
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_gets_identifier_length_for_domain()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -274,11 +244,8 @@ class DomainResolverTest extends TestCase
         $this->assertEquals(8, $this->resolver->getIdentifierLength('test.io'));
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_returns_default_identifier_length_when_not_configured()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -290,11 +257,8 @@ class DomainResolverTest extends TestCase
         $this->assertEquals(6, $this->resolver->getIdentifierLength('test.io'));
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_can_set_domain_manually()
     {
         $this->resolver->setDomain('manual.io');
@@ -302,11 +266,8 @@ class DomainResolverTest extends TestCase
         $this->assertEquals('manual.io', $this->resolver->current());
     }
 
-    /**
-     * @test
-     *
-     * @group DomainResolver
-     */
+    #[Test]
+    #[Group('DomainResolver')]
     public function it_returns_current_resolved_domain()
     {
         config(['urlshortener.domains.enabled' => true]);
@@ -316,5 +277,45 @@ class DomainResolverTest extends TestCase
         $this->resolver->resolve($request);
 
         $this->assertEquals('current.io', $this->resolver->current());
+    }
+
+    #[Test]
+    #[Group('DomainResolver')]
+    public function it_preserves_the_domain_resolver_interface_build_url_signature()
+    {
+        $resolver = new class implements DomainResolverInterface
+        {
+            public function resolve(?Request $request = null): ?string
+            {
+                return null;
+            }
+
+            public function getConfig(?string $domain = null): array
+            {
+                return [];
+            }
+
+            public function current(): ?string
+            {
+                return null;
+            }
+
+            public function isAllowed(?string $domain): bool
+            {
+                return true;
+            }
+
+            public function getPrefix(?string $domain = null): ?string
+            {
+                return null;
+            }
+
+            public function buildUrl(string $identifier, ?string $domain = null): string
+            {
+                return $identifier;
+            }
+        };
+
+        $this->assertSame('abc123', $resolver->buildUrl('abc123'));
     }
 }

--- a/tests/Unit/Services/RateLimitingTest.php
+++ b/tests/Unit/Services/RateLimitingTest.php
@@ -3,6 +3,8 @@
 namespace YorCreative\UrlShortener\Tests\Unit\Services;
 
 use Illuminate\Support\Facades\RateLimiter;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use YorCreative\UrlShortener\Builders\UrlBuilder\UrlBuilder;
 use YorCreative\UrlShortener\Exceptions\RateLimitExceededException;
 use YorCreative\UrlShortener\Services\UrlService;
@@ -35,11 +37,8 @@ class RateLimitingTest extends TestCase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     *
-     * @group RateLimiting
-     */
+    #[Test]
+    #[Group('RateLimiting')]
     public function it_allows_successful_attempts_without_rate_limiting()
     {
         $result = UrlService::attempt($this->protectedIdentifier, 'testpass123', null, '127.0.0.1');
@@ -48,11 +47,8 @@ class RateLimitingTest extends TestCase
         $this->assertEquals($this->protectedPlainText, $result->plain_text);
     }
 
-    /**
-     * @test
-     *
-     * @group RateLimiting
-     */
+    #[Test]
+    #[Group('RateLimiting')]
     public function it_rate_limits_after_max_failed_attempts()
     {
         config(['urlshortener.protection.rate_limit.max_attempts' => 3]);
@@ -69,11 +65,8 @@ class RateLimitingTest extends TestCase
         UrlService::attempt($this->protectedIdentifier, 'wrongpassword', null, '127.0.0.1');
     }
 
-    /**
-     * @test
-     *
-     * @group RateLimiting
-     */
+    #[Test]
+    #[Group('RateLimiting')]
     public function it_clears_rate_limit_on_successful_attempt()
     {
         config(['urlshortener.protection.rate_limit.max_attempts' => 5]);
@@ -94,11 +87,8 @@ class RateLimitingTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     *
-     * @group RateLimiting
-     */
+    #[Test]
+    #[Group('RateLimiting')]
     public function it_tracks_rate_limit_per_ip_and_identifier()
     {
         config(['urlshortener.protection.rate_limit.max_attempts' => 2]);
@@ -125,11 +115,8 @@ class RateLimitingTest extends TestCase
         RateLimiter::clear('urlshortener:password_attempt:192.168.1.2:'.$this->protectedIdentifier);
     }
 
-    /**
-     * @test
-     *
-     * @group RateLimiting
-     */
+    #[Test]
+    #[Group('RateLimiting')]
     public function it_provides_retry_after_seconds()
     {
         config(['urlshortener.protection.rate_limit.max_attempts' => 1]);

--- a/tests/Unit/Services/UrlServiceDeleteRestoreTest.php
+++ b/tests/Unit/Services/UrlServiceDeleteRestoreTest.php
@@ -3,6 +3,8 @@
 namespace YorCreative\UrlShortener\Tests\Unit\Services;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use YorCreative\UrlShortener\Exceptions\UrlRepositoryException;
 use YorCreative\UrlShortener\Services\UrlService;
 use YorCreative\UrlShortener\Tests\TestCase;
@@ -11,11 +13,8 @@ class UrlServiceDeleteRestoreTest extends TestCase
 {
     use DatabaseTransactions;
 
-    /**
-     * @test
-     *
-     * @group UrlService
-     */
+    #[Test]
+    #[Group('UrlService')]
     public function it_can_soft_delete_a_short_url_by_identifier()
     {
         $this->assertDatabaseHas('short_urls', [
@@ -30,11 +29,8 @@ class UrlServiceDeleteRestoreTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     *
-     * @group UrlService
-     */
+    #[Test]
+    #[Group('UrlService')]
     public function it_can_restore_a_soft_deleted_short_url()
     {
         UrlService::delete($this->identifier);
@@ -51,11 +47,8 @@ class UrlServiceDeleteRestoreTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     *
-     * @group UrlService
-     */
+    #[Test]
+    #[Group('UrlService')]
     public function it_throws_exception_when_deleting_nonexistent_identifier()
     {
         $this->expectException(UrlRepositoryException::class);
@@ -63,11 +56,8 @@ class UrlServiceDeleteRestoreTest extends TestCase
         UrlService::delete('nonexistent_identifier_'.rand(999, 999999));
     }
 
-    /**
-     * @test
-     *
-     * @group UrlService
-     */
+    #[Test]
+    #[Group('UrlService')]
     public function it_throws_exception_when_restoring_nonexistent_identifier()
     {
         $this->expectException(UrlRepositoryException::class);

--- a/tests/Unit/Services/UrlServiceTest.php
+++ b/tests/Unit/Services/UrlServiceTest.php
@@ -5,6 +5,8 @@ namespace YorCreative\UrlShortener\Tests\Unit\Services;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use YorCreative\UrlShortener\Builders\UrlBuilder\UrlBuilder;
 use YorCreative\UrlShortener\Exceptions\UrlBuilderException;
 use YorCreative\UrlShortener\Exceptions\UrlRepositoryException;
@@ -19,12 +21,10 @@ class UrlServiceTest extends TestCase
     use DatabaseTransactions;
 
     /**
-     * @test
-     *
-     * @group UrlService
-     *
      * @throws UrlRepositoryException
      */
+    #[Test]
+    #[Group('UrlService')]
     public function it_can_find_a_short_url_by_utm_combination()
     {
         // extra url to filter through
@@ -70,11 +70,8 @@ class UrlServiceTest extends TestCase
         $this->assertEquals($targetUtmCombination['utm_medium'], $shortUrls->toArray()[0]['tracing']['utm_medium']);
     }
 
-    /**
-     * @test
-     *
-     * @group UrlService
-     */
+    #[Test]
+    #[Group('UrlService')]
     public function it_can_can_find_short_url_by_the_hash()
     {
         $shortUrl = UrlService::findByHash($this->hashed);
@@ -83,11 +80,8 @@ class UrlServiceTest extends TestCase
         $this->assertTrue($this->plain_text == $shortUrl->plain_text);
     }
 
-    /**
-     * @test
-     *
-     * @group UrlService
-     */
+    #[Test]
+    #[Group('UrlService')]
     public function it_can_can_find_short_url_by_the_plain_text()
     {
         $shortUrl = UrlService::findByPlainText($this->plain_text);
@@ -96,11 +90,8 @@ class UrlServiceTest extends TestCase
         $this->assertTrue($this->identifier == $shortUrl->identifier);
     }
 
-    /**
-     * @test
-     *
-     * @group UrlService
-     */
+    #[Test]
+    #[Group('UrlService')]
     public function it_can_can_find_short_url_by_the_identifier()
     {
         $shortUrl = UrlService::findByIdentifier($this->identifier);
@@ -110,14 +101,12 @@ class UrlServiceTest extends TestCase
     }
 
     /**
-     * @test
-     *
-     * @group UrlService
-     *
      * @throws UrlBuilderException
      * @throws UrlRepositoryException
      * @throws UrlServiceException
      */
+    #[Test]
+    #[Group('UrlService')]
     public function it_can_successfully_attempt_to_verify_password()
     {
         $plain_text = 'https://something.com/really-long'.rand(5, 9999);
@@ -134,14 +123,12 @@ class UrlServiceTest extends TestCase
     }
 
     /**
-     * @test
-     *
-     * @group UrlService
-     *
      * @throws UrlBuilderException
      * @throws UrlRepositoryException
      * @throws UrlServiceException
      */
+    #[Test]
+    #[Group('UrlService')]
     public function it_can_successfully_attempt_to_verify_password_and_fail()
     {
         $plain_text = 'https://something.com/really-long'.rand(5, 9999);
@@ -156,12 +143,10 @@ class UrlServiceTest extends TestCase
     }
 
     /**
-     * @test
-     *
-     * @group UrlService
-     *
      * @throws UrlRepositoryException
      */
+    #[Test]
+    #[Group('UrlService')]
     public function it_can_attach_ownership_to_short_url()
     {
         $owner = DemoOwner::factory()->create();
@@ -186,12 +171,10 @@ class UrlServiceTest extends TestCase
     }
 
     /**
-     * @test
-     *
-     * @group UrlService
-     *
      * @throws Exception
      */
+    #[Test]
+    #[Group('UrlService')]
     public function it_can_set_an_activation_time_successfully()
     {
         UrlService::shorten('https://something.com/activation-test')
@@ -201,11 +184,34 @@ class UrlServiceTest extends TestCase
         $this->assertTrue(ShortUrl::where('plain_text', 'https://something.com/activation-test')->first()->hasActivation());
     }
 
-    /**
-     * @test
-     *
-     * @group UrlService
-     */
+    #[Test]
+    #[Group('UrlService')]
+    public function it_treats_zero_open_limit_as_unlimited()
+    {
+        $plainText = 'https://something.com/no-limit/'.rand(999, 999999);
+        $url = UrlService::shorten($plainText)
+            ->withOpenLimit(0)
+            ->build();
+
+        $identifier = str_replace($this->base, '', $url);
+        $shortUrl = UrlService::findByIdentifier($identifier);
+
+        $this->assertNull($shortUrl->limit);
+    }
+
+    #[Test]
+    #[Group('UrlService')]
+    public function it_rejects_negative_open_limit()
+    {
+        $this->expectException(UrlBuilderException::class);
+        $this->expectExceptionMessage('cannot be negative');
+
+        UrlService::shorten('https://something.com/bad-limit/'.rand(999, 999999))
+            ->withOpenLimit(-1);
+    }
+
+    #[Test]
+    #[Group('UrlService')]
     public function it_can_find_or_create_returns_existing_short_url()
     {
         $plain_text = 'https://testing.com/findorcreate/existing/'.rand(999, 999999);
@@ -220,11 +226,8 @@ class UrlServiceTest extends TestCase
         $this->assertEquals($plain_text, $result->plain_text);
     }
 
-    /**
-     * @test
-     *
-     * @group UrlService
-     */
+    #[Test]
+    #[Group('UrlService')]
     public function it_can_find_or_create_returns_builder_for_new_url()
     {
         $plain_text = 'https://testing.com/findorcreate/new/'.rand(999, 999999);
@@ -235,11 +238,8 @@ class UrlServiceTest extends TestCase
         $this->assertInstanceOf(UrlBuilder::class, $result);
     }
 
-    /**
-     * @test
-     *
-     * @group UrlService
-     */
+    #[Test]
+    #[Group('UrlService')]
     public function it_throws_exception_when_finding_nonexistent_identifier()
     {
         $this->expectException(UrlRepositoryException::class);

--- a/tests/Unit/Services/UrlValidatorTest.php
+++ b/tests/Unit/Services/UrlValidatorTest.php
@@ -2,6 +2,8 @@
 
 namespace YorCreative\UrlShortener\Tests\Unit\Services;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use YorCreative\UrlShortener\Exceptions\UrlBuilderException;
 use YorCreative\UrlShortener\Services\UrlValidator;
 use YorCreative\UrlShortener\Tests\TestCase;
@@ -16,11 +18,8 @@ class UrlValidatorTest extends TestCase
         config(['urlshortener.url_validation.enabled' => true]);
     }
 
-    /**
-     * @test
-     *
-     * @group UrlValidator
-     */
+    #[Test]
+    #[Group('UrlValidator')]
     public function it_allows_valid_https_urls()
     {
         $this->expectNotToPerformAssertions();
@@ -30,11 +29,8 @@ class UrlValidatorTest extends TestCase
         UrlValidator::validate('https://example.com:8080/page');
     }
 
-    /**
-     * @test
-     *
-     * @group UrlValidator
-     */
+    #[Test]
+    #[Group('UrlValidator')]
     public function it_allows_valid_http_urls()
     {
         $this->expectNotToPerformAssertions();
@@ -42,11 +38,8 @@ class UrlValidatorTest extends TestCase
         UrlValidator::validate('http://example.com/path/to/page');
     }
 
-    /**
-     * @test
-     *
-     * @group UrlValidator
-     */
+    #[Test]
+    #[Group('UrlValidator')]
     public function it_rejects_urls_without_scheme()
     {
         $this->expectException(UrlBuilderException::class);
@@ -55,11 +48,8 @@ class UrlValidatorTest extends TestCase
         UrlValidator::validate('example.com/path');
     }
 
-    /**
-     * @test
-     *
-     * @group UrlValidator
-     */
+    #[Test]
+    #[Group('UrlValidator')]
     public function it_rejects_javascript_protocol()
     {
         $this->expectException(UrlBuilderException::class);
@@ -68,11 +58,8 @@ class UrlValidatorTest extends TestCase
         UrlValidator::validate('javascript:alert("XSS")');
     }
 
-    /**
-     * @test
-     *
-     * @group UrlValidator
-     */
+    #[Test]
+    #[Group('UrlValidator')]
     public function it_rejects_data_protocol()
     {
         $this->expectException(UrlBuilderException::class);
@@ -81,11 +68,8 @@ class UrlValidatorTest extends TestCase
         UrlValidator::validate('data:text/html,<script>alert("XSS")</script>');
     }
 
-    /**
-     * @test
-     *
-     * @group UrlValidator
-     */
+    #[Test]
+    #[Group('UrlValidator')]
     public function it_rejects_file_protocol()
     {
         $this->expectException(UrlBuilderException::class);
@@ -94,11 +78,8 @@ class UrlValidatorTest extends TestCase
         UrlValidator::validate('file:///etc/passwd');
     }
 
-    /**
-     * @test
-     *
-     * @group UrlValidator
-     */
+    #[Test]
+    #[Group('UrlValidator')]
     public function it_rejects_localhost_urls()
     {
         $this->expectException(UrlBuilderException::class);
@@ -107,11 +88,8 @@ class UrlValidatorTest extends TestCase
         UrlValidator::validate('http://localhost/admin');
     }
 
-    /**
-     * @test
-     *
-     * @group UrlValidator
-     */
+    #[Test]
+    #[Group('UrlValidator')]
     public function it_rejects_loopback_ip()
     {
         $this->expectException(UrlBuilderException::class);
@@ -120,11 +98,8 @@ class UrlValidatorTest extends TestCase
         UrlValidator::validate('http://127.0.0.1/admin');
     }
 
-    /**
-     * @test
-     *
-     * @group UrlValidator
-     */
+    #[Test]
+    #[Group('UrlValidator')]
     public function it_rejects_private_ip_ranges()
     {
         $this->expectException(UrlBuilderException::class);
@@ -133,11 +108,8 @@ class UrlValidatorTest extends TestCase
         UrlValidator::validate('http://192.168.1.1/admin');
     }
 
-    /**
-     * @test
-     *
-     * @group UrlValidator
-     */
+    #[Test]
+    #[Group('UrlValidator')]
     public function it_rejects_aws_metadata_endpoint()
     {
         $this->expectException(UrlBuilderException::class);
@@ -146,11 +118,8 @@ class UrlValidatorTest extends TestCase
         UrlValidator::validate('http://169.254.169.254/latest/meta-data/');
     }
 
-    /**
-     * @test
-     *
-     * @group UrlValidator
-     */
+    #[Test]
+    #[Group('UrlValidator')]
     public function it_allows_urls_when_validation_disabled()
     {
         config(['urlshortener.url_validation.enabled' => false]);
@@ -162,11 +131,8 @@ class UrlValidatorTest extends TestCase
         UrlValidator::validate('http://localhost/admin');
     }
 
-    /**
-     * @test
-     *
-     * @group UrlValidator
-     */
+    #[Test]
+    #[Group('UrlValidator')]
     public function it_allows_private_ips_when_config_disabled()
     {
         config(['urlshortener.url_validation.block_private_ips' => false]);
@@ -174,5 +140,100 @@ class UrlValidatorTest extends TestCase
         $this->expectNotToPerformAssertions();
 
         UrlValidator::validate('http://192.168.1.1/admin');
+    }
+
+    #[Test]
+    #[Group('UrlValidator')]
+    public function it_rejects_hosts_that_resolve_to_private_ips()
+    {
+        config(['urlshortener.url_validation.resolve_dns_private_ips' => true]);
+
+        $validator = new class extends UrlValidator
+        {
+            public static function validateWithStubbedDns(string $url): void
+            {
+                self::validate($url);
+            }
+
+            protected static function resolveHostIps(string $host): array
+            {
+                return $host === 'example.com' ? ['10.0.0.5'] : [];
+            }
+        };
+
+        $this->expectException(UrlBuilderException::class);
+        $this->expectExceptionMessage('resolves to a private/internal IP');
+
+        $validator::validateWithStubbedDns('https://example.com/resource');
+    }
+
+    #[Test]
+    #[Group('UrlValidator')]
+    public function it_skips_dns_private_ip_checks_when_config_disabled()
+    {
+        config(['urlshortener.url_validation.resolve_dns_private_ips' => false]);
+
+        $validator = new class extends UrlValidator
+        {
+            public static function validateWithStubbedDns(string $url): void
+            {
+                self::validate($url);
+            }
+
+            protected static function resolveHostIps(string $host): array
+            {
+                throw new \RuntimeException('DNS resolution should not be called.');
+            }
+        };
+
+        $this->expectNotToPerformAssertions();
+
+        $validator::validateWithStubbedDns('https://example.com/resource');
+    }
+
+    #[Test]
+    #[Group('UrlValidator')]
+    public function it_does_not_resolve_dns_by_default()
+    {
+        $validator = new class extends UrlValidator
+        {
+            public static function validateWithStubbedDns(string $url): void
+            {
+                self::validate($url);
+            }
+
+            protected static function resolveHostIps(string $host): array
+            {
+                throw new \RuntimeException('DNS resolution should not be called.');
+            }
+        };
+
+        $this->expectNotToPerformAssertions();
+
+        $validator::validateWithStubbedDns('https://example.com/resource');
+    }
+
+    #[Test]
+    #[Group('UrlValidator')]
+    public function it_allows_hosts_when_dns_resolution_returns_no_ips()
+    {
+        config(['urlshortener.url_validation.resolve_dns_private_ips' => true]);
+
+        $validator = new class extends UrlValidator
+        {
+            public static function validateWithStubbedDns(string $url): void
+            {
+                self::validate($url);
+            }
+
+            protected static function resolveHostIps(string $host): array
+            {
+                return [];
+            }
+        };
+
+        $this->expectNotToPerformAssertions();
+
+        $validator::validateWithStubbedDns('https://unresolved.example/resource');
     }
 }

--- a/tests/Unit/Services/UtilityServiceTest.php
+++ b/tests/Unit/Services/UtilityServiceTest.php
@@ -4,6 +4,8 @@ namespace YorCreative\UrlShortener\Tests\Unit\Services;
 
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use YorCreative\UrlShortener\Exceptions\UtilityServiceException;
 use YorCreative\UrlShortener\Services\UtilityService;
 use YorCreative\UrlShortener\Tests\TestCase;
@@ -11,22 +13,17 @@ use YorCreative\UrlShortener\Tests\TestCase;
 class UtilityServiceTest extends TestCase
 {
     /**
-     * @test
-     *
-     * @group UtilityService
-     *
      * @throws UtilityServiceException
      */
+    #[Test]
+    #[Group('UtilityService')]
     public function it_can_successfully_get_an_instance_of_the_encrypter()
     {
         $this->assertInstanceOf(Encrypter::class, UtilityService::getEncrypter());
     }
 
-    /**
-     * @test
-     *
-     * @group UtilityService
-     */
+    #[Test]
+    #[Group('UtilityService')]
     public function it_can_get_the_redirect_code()
     {
         $this->assertEquals(
@@ -35,11 +32,8 @@ class UtilityServiceTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     *
-     * @group UtilityService
-     */
+    #[Test]
+    #[Group('UtilityService')]
     public function it_can_get_redirect_headers()
     {
         $request = Request::create('something-short.com/not-really');
@@ -58,11 +52,8 @@ class UtilityServiceTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     *
-     * @group UrlRepository
-     */
+    #[Test]
+    #[Group('UrlRepository')]
     public function it_can_construct_redirect_headers_with_dynamic_headers()
     {
         $this->assertEquals([
@@ -71,11 +62,8 @@ class UtilityServiceTest extends TestCase
         ], UtilityService::constructRedirectHeaders(['test' => 'something']));
     }
 
-    /**
-     * @test
-     *
-     * @group UrlRepository
-     */
+    #[Test]
+    #[Group('UrlRepository')]
     public function it_can_construct_redirect_headers()
     {
         $this->assertEquals([

--- a/tests/Unit/Strategies/FilterClicks/FilterClicksStrategyTest.php
+++ b/tests/Unit/Strategies/FilterClicks/FilterClicksStrategyTest.php
@@ -3,6 +3,8 @@
 namespace YorCreative\UrlShortener\Tests\Unit\Services;
 
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use YorCreative\UrlShortener\Strategies\FilterClicks\FilterClicksStrategy;
 use YorCreative\UrlShortener\Strategies\FilterClicks\Filters\BatchFilter;
 use YorCreative\UrlShortener\Strategies\FilterClicks\Filters\IdentifierFilter;
@@ -34,11 +36,8 @@ class FilterClicksStrategyTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     *
-     * @group FilterClickStrategy
-     */
+    #[Test]
+    #[Group('FilterClickStrategy')]
     public function it_can_add_filter_strategies()
     {
         $filterStrategy = new FilterClicksStrategy;
@@ -50,11 +49,8 @@ class FilterClicksStrategyTest extends TestCase
         $this->assertCount(6, $filterStrategy->getStrategies());
     }
 
-    /**
-     * @test
-     *
-     * @group FilterClickStrategy
-     */
+    #[Test]
+    #[Group('FilterClickStrategy')]
     public function it_can_can_process_outcome_filter()
     {
         $filterQuery = [
@@ -66,11 +62,8 @@ class FilterClicksStrategyTest extends TestCase
         $this->assertTrue((new OutcomeFilter)->canProcess($filterQuery));
     }
 
-    /**
-     * @test
-     *
-     * @group FilterClickStrategy
-     */
+    #[Test]
+    #[Group('FilterClickStrategy')]
     public function it_can_can_process_batch_filter()
     {
         $filterQuery = [
@@ -81,11 +74,8 @@ class FilterClicksStrategyTest extends TestCase
         $this->assertTrue((new BatchFilter)->canProcess($filterQuery));
     }
 
-    /**
-     * @test
-     *
-     * @group FilterClickStrategy
-     */
+    #[Test]
+    #[Group('FilterClickStrategy')]
     public function it_can_can_process_identifier_filter()
     {
         $filterQuery = [
@@ -97,11 +87,8 @@ class FilterClicksStrategyTest extends TestCase
         $this->assertTrue((new IdentifierFilter)->canProcess($filterQuery));
     }
 
-    /**
-     * @test
-     *
-     * @group FilterClickStrategy
-     */
+    #[Test]
+    #[Group('FilterClickStrategy')]
     public function it_can_can_process_status_filter()
     {
         $filterQuery = [
@@ -113,11 +100,8 @@ class FilterClicksStrategyTest extends TestCase
         $this->assertTrue((new StatusFilter)->canProcess($filterQuery));
     }
 
-    /**
-     * @test
-     *
-     * @group FilterClickStrategy
-     */
+    #[Test]
+    #[Group('FilterClickStrategy')]
     public function it_can_can_process_ownership_filter()
     {
         $filterQuery = [
@@ -129,11 +113,8 @@ class FilterClicksStrategyTest extends TestCase
         $this->assertTrue((new OwnershipFilter)->canProcess($filterQuery));
     }
 
-    /**
-     * @test
-     *
-     * @group FilterClickStrategy
-     */
+    #[Test]
+    #[Group('FilterClickStrategy')]
     public function it_can_can_process_tracing_utm_id_filter()
     {
         $filterQuery = [
@@ -146,11 +127,8 @@ class FilterClicksStrategyTest extends TestCase
         $this->assertTrue((new TracingIdFilter)->canProcess($filterQuery));
     }
 
-    /**
-     * @test
-     *
-     * @group FilterClickStrategy
-     */
+    #[Test]
+    #[Group('FilterClickStrategy')]
     public function it_can_can_process_tracing_utm_campaign_filter()
     {
         $filterQuery = [
@@ -163,11 +141,8 @@ class FilterClicksStrategyTest extends TestCase
         $this->assertTrue((new TracingCampaignFilter)->canProcess($filterQuery));
     }
 
-    /**
-     * @test
-     *
-     * @group FilterClickStrategy
-     */
+    #[Test]
+    #[Group('FilterClickStrategy')]
     public function it_can_can_process_tracing_utm_source_filter()
     {
         $filterQuery = [
@@ -180,11 +155,8 @@ class FilterClicksStrategyTest extends TestCase
         $this->assertTrue((new TracingSourceFilter)->canProcess($filterQuery));
     }
 
-    /**
-     * @test
-     *
-     * @group FilterClickStrategy
-     */
+    #[Test]
+    #[Group('FilterClickStrategy')]
     public function it_can_can_process_tracing_utm_medium_filter()
     {
         $filterQuery = [
@@ -197,11 +169,8 @@ class FilterClicksStrategyTest extends TestCase
         $this->assertTrue((new TracingMediumFilter)->canProcess($filterQuery));
     }
 
-    /**
-     * @test
-     *
-     * @group FilterClickStrategy
-     */
+    #[Test]
+    #[Group('FilterClickStrategy')]
     public function it_can_can_process_tracing_utm_content_filter()
     {
         $filterQuery = [
@@ -214,11 +183,8 @@ class FilterClicksStrategyTest extends TestCase
         $this->assertTrue((new TracingContentFilter)->canProcess($filterQuery));
     }
 
-    /**
-     * @test
-     *
-     * @group FilterClickStrategy
-     */
+    #[Test]
+    #[Group('FilterClickStrategy')]
     public function it_can_can_process_tracing_utm_term_filter()
     {
         $filterQuery = [

--- a/tests/Unit/Traits/ShortUrlHelperTest.php
+++ b/tests/Unit/Traits/ShortUrlHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use YorCreative\UrlShortener\Exceptions\UrlServiceException;
 use YorCreative\UrlShortener\Tests\Models\DemoOwner;
 use YorCreative\UrlShortener\Tests\TestCase;
@@ -9,11 +11,8 @@ class ShortUrlHelperTest extends TestCase
 {
     use ShortUrlHelper;
 
-    /**
-     * @test
-     *
-     * @group Traits
-     */
+    #[Test]
+    #[Group('Traits')]
     public function it_can_validate_ownership_is_array_of_models_filter()
     {
         $model = DemoOwner::factory()->create();
@@ -27,11 +26,8 @@ class ShortUrlHelperTest extends TestCase
         $this->assertEquals($filter, $this->filterClickValidation($filter));
     }
 
-    /**
-     * @test
-     *
-     * @group Traits
-     */
+    #[Test]
+    #[Group('Traits')]
     public function it_can_validate_ownership_is_not_array_of_models_filter()
     {
         $model = DemoOwner::factory()->create();
@@ -52,11 +48,48 @@ class ShortUrlHelperTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     *
-     * @group Traits
-     */
+    #[Test]
+    #[Group('Traits')]
+    public function it_can_validate_failure_activation_outcome_filter()
+    {
+        $filter = [
+            'outcome' => [
+                6,
+            ],
+        ];
+
+        $this->assertEquals($filter, $this->filterClickValidation($filter));
+    }
+
+    #[Test]
+    #[Group('Traits')]
+    public function it_can_validate_status_array_filter()
+    {
+        $filter = [
+            'status' => [
+                'active',
+                'expired',
+                'expiring',
+            ],
+        ];
+
+        $this->assertEquals($filter, $this->filterClickValidation($filter));
+    }
+
+    #[Test]
+    #[Group('Traits')]
+    public function it_rejects_scalar_status_filter()
+    {
+        $this->expectException(UrlServiceException::class);
+        $this->expectExceptionMessage('status');
+
+        $this->filterClickValidation([
+            'status' => 'active',
+        ]);
+    }
+
+    #[Test]
+    #[Group('Traits')]
     public function it_can_build_short_url()
     {
         $host = config('urlshortener.branding.host') ?? 'localhost.test';

--- a/tests/Unit/UrlShortenerServiceProviderTest.php
+++ b/tests/Unit/UrlShortenerServiceProviderTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace YorCreative\UrlShortener\Tests\Unit;
+
+use Illuminate\Support\ServiceProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use YorCreative\UrlShortener\Tests\TestCase;
+use YorCreative\UrlShortener\Tests\TestUrlShortenerServiceProvider;
+
+class UrlShortenerServiceProviderTest extends TestCase
+{
+    #[Test]
+    #[Group('ServiceProvider')]
+    public function it_registers_tagged_publish_groups()
+    {
+        $provider = TestUrlShortenerServiceProvider::class;
+
+        $this->assertSame(
+            [dirname(__DIR__, 2).'/src/Utility/Config/urlshortener.php' => config_path('urlshortener.php')],
+            ServiceProvider::pathsToPublish($provider, 'urlshortener-config')
+        );
+
+        $this->assertSame(
+            [dirname(__DIR__, 2).'/src/Utility/Views' => resource_path('views/yorcreative/urlshortener')],
+            ServiceProvider::pathsToPublish($provider, 'urlshortener-views')
+        );
+
+        $this->assertSame(
+            [dirname(__DIR__, 2).'/src/Utility/Migrations' => database_path('migrations')],
+            ServiceProvider::pathsToPublish($provider, 'urlshortener-migrations')
+        );
+    }
+
+    #[Test]
+    #[Group('ServiceProvider')]
+    public function it_keeps_existing_untagged_publish_paths()
+    {
+        $paths = ServiceProvider::pathsToPublish(TestUrlShortenerServiceProvider::class);
+
+        $this->assertArrayHasKey(dirname(__DIR__, 2).'/src/Utility/Views', $paths);
+        $this->assertArrayHasKey(dirname(__DIR__, 2).'/src/Utility/Config', $paths);
+    }
+}


### PR DESCRIPTION
## Summary

Adds Laravel 13 support and hardens the redirect, routing, limit, and URL-validation paths. The redirect flow no longer reloads the short URL mid-request, custom and prefix-less domain routes now resolve correctly, and several boundary/semantic inconsistencies (open limit of 0, exact-second expiration, scalar vs array status filters) are fixed. Includes a new opt-in SSRF-style DNS check and the PHPUnit attribute migration.

## Changes

### Framework & tooling
- Laravel 13 + Testbench 11 support; CI matrix trimmed to Laravel 12-13 / PHP 8.2-8.5
- `prefer-stable` replaces `minimum-stability: dev`
- PHPUnit doc-comment metadata → attributes (no PHPUnit 11 deprecations)
- Tagged publishing for config / views / migrations
- `.gitattributes` `export-ignore` to slim the Composer dist install

### Redirect & click tracking
- `findForRedirectByIdentifier` selects a minimal column set; clicks are tracked against the loaded model instead of re-querying (one `short_urls` read per redirect)
- `ShortUrlExpired` is dispatched with a fully-loaded `ShortUrl` (relations intact)

### Routing & prefixes
- Registered `withPrefix()` overrides now affect generated URLs; unregistered prefixes are rejected so we never hand out URLs the package can't route
- All configured prefixes get routes; domains with `prefix => null` are served at the host root via per-domain `Route::domain()` (host resolution strategy only)

### Limits, status & validation
- `withOpenLimit(0)` means unlimited (normalized on write, and `hasLimit()` treats both `null` and `0` as unlimited so legacy/direct `0` rows behave consistently); negative limits are rejected
- Status filters validated as arrays; `expired` now uses `<=` so a URL at its exact expiration second matches the redirect's `now >= expiration` and is the exact complement of `active`
- New failure-activation outcome filter

### Security
- Opt-in DNS check rejecting hosts that resolve to private/reserved IPs (`resolve_dns_private_ips`, **disabled by default** — enabling adds blocking, un-timed DNS lookups per shorten). Literal-IP hosts skip the lookup. Direct private-IP/IP-like-host blocking remains on by default.

## Compatibility / behavior notes
- No breaking API changes.
- One default change: `resolve_dns_private_ips` defaults to `false`; set `URL_SHORTENER_RESOLVE_DNS_PRIVATE_IPS=true` to enable.
- `withOpenLimit(0)` semantics changed from "always blocked" to "unlimited"; existing `limit = 0` rows now behave as unlimited.
- Root-domain routing requires the `host` resolution strategy.

## Test plan
- `composer test` — **164 passing, 291 assertions**
- `vendor/bin/pint` — clean (108 files)
- New coverage: redirect-without-reload, expired-event payload, root-level routing, zero-limit-as-unlimited, "0" prefix, exact-second expiration, DNS default-off, status array validation, custom-prefix rejection.